### PR TITLE
Add OCR notes for correction

### DIFF
--- a/drafts/chambers_notes_ocr.md
+++ b/drafts/chambers_notes_ocr.md
@@ -1,0 +1,822 @@
+# NOTES.
+
+*References are made to the text by Pages and Lines, e.g., 3, 10 means page 3, line 10.*
+
+## INTRODUCTORY NOTE TO SECTIONS 1 AND 2 
+During the first few lessons, while the Greek Alphabet [REF] and the portions of Grammar given below are being learnt, it is intended that these two sections should be used for practice in reading, and should be translated by instalments to the class.
+
+Nouns should be declined *viva voce*, and also on paper, with or without an adjective and the article, *e.g.*, ἡ μικρά γῆ, ἡ χαλεπὴ ὁδός, στενός Ἰσθμός. Similarly the Pres. Ind. of verbs should be conjugated, *e.g.*, ἔχειν.
+
+Attention should be drawn to cognate words in English and Latin (*e.g.*, κόλπ-ος = *gulf*, μέσος = *medius*), and also to the close connection between the terminations of 1st and 2nd Declen. nouns in Latin and Greek.
+
+As occasion arises, emphasis should be laid on (A) the connection between sentences, and (B) the uses of the Article. The rules are collected here for convenience, but, of course, only one or two points will be dealt with in any one lesson.
+
+### A. 
+(i.) Every sentence is connected with its predecessor by a conjunction or connecting particle; of these the commonest are καί *and* [REF]; δέ *but* , unemphatic [REF]; γάρ *for* [REF]; ἀλλά *but*, emphatic [REF]; οὖν *therefore* [REF]; τε *and* [REF]; μέντοι *however* [REF]; ἔπειτα *then* [REF]. Notice that δέ, γάρ, οὖν, τε, μέντοι, do not come first word in the sentence.
+
+(ii.) There is one exception to the above rule. When the demonstrative pronoun οὗτος *this*, or its derivatives οὕτω *thus*, τοιοῦτος *οf such a kind*, sum up what has already been stated, no conjunction is required [REF]; similarly, when the demonstrative pronoun ὅδε *this*, or its derivatives, ὧδε *thus*, τοιόσδε *of such a character*, look forward to what is coming, no conjunction is required with the following sentence [REF].
+
+(iii.) When two words or groups of words are parallel, they may be joined by τε ... καί ... [REF] or καί ... καί ... [REF], *both ... and ...*; in English we seldom use the word *both*, and therefore leave τε untranslated; this is necessarily the case when τε ... καί ... καί ... occurs [REF].
+
+(iv.) When two clauses or sentences are contrasted, μέν ... δέ ..., *on the one hand ... but on the other ...*, are used. μέν (just like τε *both*) looks forward to something which is coming, but δέ connects with what has gone before, and means BUT *on the other hand*, not simply *on the other hand*. The contrast between the μέν clause and the δέ clause, is often so slight that we do not translate μέν at all, and translate δέ by *but*, or even by *and* [REF].
+ 
+πρῶτον μέν *firstly*, is habitually answered by ἔπειτα *secondly*, not by ἔπειτα δέ, as we should expect [REF].
+
+### B. The uses of the Article. 
+(See also headings to Ex. 1-6.)
+
+(i.) It is habitually used with the names of countries, islands and towns, ἡ Ἑλλάς *Greece* [REF]; ἡ Εὔβοια *Euboea* [REF]; αἱ Ἀθῆναι *Athens*; and with Proper Nouns, if the person is well known or has previously been mentioned, ὁ Πέλοψ *Pelops* [REF].
+
+(ii.) It is used as an unemphatic possessive pronoun, διὰ τὸν πλοῦτον *on account of his wealth* [REF]; τὰς πηγὰς ἔχει *has its springs* [REF].
+
+(iii.) It is placed, as in English, before an attributive adjective, or may be repeated with the adjective after the noun, ὁ Κορίνθιος κόλπος *the Corinthian gulf* [REF]; ἐς τὸν κόλπον τὸν Ἰόνιον *into the Ionian gulf* [REF].
+
+(iv.) Instead of an adjective, the attribute may be a prepositional phrase, an adverb, or a genitive case, ἡ πρὸς Βορέαν μοῖρα lit. *the towards-north part*, i.e., *the northern part* [REF]; οἱ γεωργοὶ οἱ ἐν τῇ μεσογείᾳ *the farmers in the interior* [REF]; οἱ νῦν ἐπιχώριοι lit. *the now inhabitants*, i.e., *the present inhabitants* [REF]; ὁ Θουκυδίδης ὁ Ὀλόρου *Thucydides the (son) of Olorus* [REF].
+
+(v.) It is used with abstract nouns, ἡ ἐπιμειξία *communication* [REF]; ὁ κίνδυνος *danger* [REF].
+
+(vi.) It is omitted with a predicated adjective or noun, τῶν νήσων μεγίστη ἐστὶν ἡ Εὔβοια *Euboea is the largest of the islands* [REF].
+
+(vii.) It denotes a whole class, δύο αἰτίαι προάγουσι τοὺς ὑπηκόους ἐς τὸν πόλεμον *two causes lead subject peoples into war* [REF].
+
+(viii.) The Article was originally a demonstrative pronoun, and can be used, if accompanied by μέν or δέ, meaning *he*, *she*, *it* and *they*. This is especially common in expressions like οἱ μέν ... οἱ δέ ... *these ... but those ...*, *some ... but others ...*, οἱ μὲν φίλοι εἰσὶ τῷ Ἑλληνικῷ δήμῳ, οἱ δὲ ξύμμαχοί εἰσι τῶν Τούρκων *some are friendly to the Greek nation, but others are the allies of the Turks* [REF]; τὰ μὲν αἰσχύνην φέρει, ἐκ δὲ τῶν δόξαν λαμβάνουσι *some deeds bring disgrace, but from others they win honour* [REF]. Notice the order when a preposition is used.
+
+oi δέ necessarily comes first in its clause, A. (iv.): oi μέν generally comes first, but may be preceded by a word or group of words which belongs to both clauses, see [REF]. It is not necessary that, when οἱ δέ is used, oi μέν should have preceded, but oi δέ must not refer to the subject of the previous sentence, see [REF].
+
+(ix.) The Article with an adjective, a prepositional phrase, an adverb, or a genitive case, forms a noun-equivalent, οἱ παλαιοί *the ancients* [REF]; ἡ παραθαλάσσιος *the coast* [REF]; τὸ δίκαιον *justice* [REF]; οἱ κάτω *those on the coast* [REF]; οἱ ἐν τῇ μεσογείᾳ *those in the interior* [REF]; οἱ κατ' ἤπειρον *those along the mainland* [REF]; οἱ ἐν τῇ ξυνωμοσίᾳ *the members of the conspiracy* [REF]; οἱ μετ' αὐτοῦ *his companions* [REF]; τὰ ἐν τῷ στρατοπέδῳ *the state of the camp* [REF]; τὰ περὶ τῆς ξυνωμοσίας *the facts about the conspiracy* [REF]; τὰ τῶν Τούρκων *the property of the Turks* [REF].
+
+## Section 1. 
+
+ἡ μάχη, ὥρα, [REF]; ὁ δοῦλος, [REF]; στενός, μικρός (Masc. and Fem.), [REF].
+
+Pres. Ind. of εἶναι, εἰμί ; of λύειν, λύω, [REF].
+
+1. έστι μέν, ἔχει δέ. Introd. Note A. (iv.).
+2. ἡ Ἑλλάς. ίντροδ. Νote B. (i.).
+3. αὐτός, -ή, -ό, in the Nom. means *self* (Lat. *ipse*), but the Oblique Cases are also used for the Personal Pronoun, *him, her, it*. αὐτῶν = *earum*.
+4. ήπειρος *mainland*; thus the Western coast of Northern Greece was called Epirus in contrast with the adjacent islands.
+5. ἡ πρὸς Βορέαν μοῖρα. Introd. Note B. (iv.).
+6. χερσόνησος, lit. *dry-land-island*; νῆσος = *island*.
+7. ἡ πρὸς μεσημβρίαν *the southern*, μοῖρα is understood in Greek, as *part* is in English.
+8. οἱ μὲν παλαιοί. Introd. Note B. (ix.). μέν is answered by δέ in [REF]. 
+8. Πελοπόννησον, lit. *island of Pelops*. According to tradition Pelops, the son of Tantalus, came from Lydia and became King of Pisa in Elis; see *Mythological Dictionary*.
+9.  ἐκ τῆς Ἀσίας *from Asia*; prepositions meaning *from* take the Gen. in Greek, because the Gen. expresses separation, like the Latin Abl. of separation.
+10. αφικόμενος *having come*; Participles are given in the Vocab. as adjectives.
+11. ὡς *as*. Thucydides, the son of Olorus, was an Athenian, who wrote the history of the Peloponnesian War (B.C. 431-404).
+12. ὁ Ὀλόρου. Introd. Note B. (iv.).
+13. τε ... καί. Introd. Note A. (iii.).
+14. διὰ τὸν πλοῦτον *on account of his wealth*. Introd. Note B. (ii.). 
+15. οἱ νῦν ἐπιχώριοι *the present inhabitants*. Introd. Note B. (iv.). 
+16. For this use of an adverb for an adjective, compare 1 Tim. v. 23, *thine often infirmities*.
+17. καί ... καί. Introd. Note A. (iii.).
+18. The modern name of the Achelous is Aspropotamo, meaning White-river.
+19. τὰς πηγάς *its springs*, *cf*. [REF] *n*.
+20. τὸν Ἰόνιον. Introd. Note B. (iii.).
+21. διά with Gen. means *through* (as here), or *by means of*; with Acc. it means *on account of*.
+22. ἡ ἐπιμειξία *communication*. Introd. Note B. (v.).
+23. τοῖς ... παραθαλασσίοις, the Article with a prepositional phrase or with an adjective is equivalent to a noun, *for those in the interior and on the coast*. Introd. Note B. (ix.).
+24. μεγίστη *the largest*; the Article is omitted with a *predicated* adjective in Greek. Introd. Note B. (vi.).
+25. τε ... καί ... καί. Introd. Note A. (iii.).
+
+## Section 2. 
+τὸ δῶρον, p. 143 ; Neut. of στενός, μικρός, p. 145 ; δόξα, p. 142; ὅδε, p. 146.
+1.  κarà την ȧρxýv at the beginning.
+ὅδε this is declined like the Article with de added; when it is used with nouns, the Article must also be used immediately before the noun ; ὁ πόλεμος ὅδε οι ὅδε ὁ πόλεμος this war. For exception, see 5, 4 n.
+1.  οἱ μέν oi δέ.—Introd. Note B. (viii.).
+...
+1.  karà kwμas åteixíorovs in unfortified villages.
+Compound adjectives (a-reixoros un-walled) have no separate form for the Fem. Cf. παραθαλάσσιος, πολυάνθρωπος.
+1.  oi de κáτw but those on the coast, the Article with an adverb forming the equivalent of a noun.-Introd. Note B. (ix.).
+99 66 
+κάτω properly down. The Greeks spoke of "going down to the coast, up into the interior," and "on the high seas," just as we do; the coast is regarded as the lowest point.
+1.  Tòv Tλelotov Toû Bíov the greater part of their livelihood; the adjective is made to agree in gender with the noun in the (partitive) Genitive.
+2.  mapabaλáσoios sc. yn.-Introd. Note B. (ix.).
+3.  vaνrike oxλw with a crowd of sailors; with and by are expressed in Greek by the Dative, corresponding with the Latin (instrumental) Ablative.
+4.  oi ev Ty μeooyeía.-Introd. Note B. (iv.).
+5.  τούς τε ἄλλους to pay tithes of their produce and other taxes; the English order is the reverse of the Greek order.
+NOTES TO PAGES 4, 5 
+1.  Sσre with Ind. introduces a Consecutive Clause, so that. 29. δι' ἁρπαγῆς, see l. 3 n.
+63 
+1.  ὥσπερ κλέπται as Clephts. The Clephts (lit. robbers) were those Greeks, who in defiance of the Turkish authorities carried on a predatory warfare from the hills. Many of them were popular heroes, and their existence helped to keep alive the patriotism of the Greeks.
+Tà Tây TоúρKwv the property of the Turks.-Introd. Note B. (ix.). Page 5, 1. Tŵν πρiv piλwv, see 3, 11.
+1.
+Kívduvos.-Introd. Note B. (v.).
+οὕτω δή in this way. δή only emphasises οὕτω, which sums up what precedes. For omission of conjunction, see Introd. Note A. (ii.).
+Section 3. deσtóτns, p. 143.
+1. dúo airía aide these two causes. If a numeral is used, ὅδε does not require the Article to be inserted with the noun, contrary to the rule given on 4, 12.
+TOÙS VπηKÓοvs subject peoples (in general). The Article denotes a whole class.-Introd. Note B. (vii.).
+1. ἡ τιμωρία τῶν ἀδικιῶν vengeance for their wrongs.
+2. após against.
+3. dia ráde for the following reasons.
+For the omission of a con
+junction in the following sentence, see Introd. Note A. (ii.).
+πρŵтоν μέν is answered by ἔπειτα in l. 16.—Introd. Note A. (iv.). 10. or that introduces a noun-clause, after verbs of thinking, knowing, feeling, seeing, saying, etc.
+avroi (they) themselves, cf. 3, 3 n.
+1.  exovσi Tous deσπóras á§vvérovs lit. they have their masters ignorant, i.e., the masters they have are ignorant. ἀξυνέτους is 8 predicated adjective, and so has no Article. This is the common idiom with ἔχειν.
+• 
+1.  ἄδικα πάσχουσιν ὑπό lit. suffer unjust things by, ie., suffer unjustly at the hands of. iró with Gen. is the ordinary way of expressing the Agent after Passive Verbs (Lat. ab with Abl.); it is also used, as here, with Intransitive Verbs which have a Passive meaning, are unjustly treated by.
+2.  oioi reioí lit. are such as to, i.e., are able to; so oióv r' éotív it is possible. Te in early Greek was added to Relative words, e.g., Sote, and in such cases means nothing at all.
+• 
+· 
+δίκην λαμβάνειν παρά to take vengeance on, lit. to get punishment from. napú with Gen. meaning from is only used of persons. 19. οὐδέν dikalov the judges do not care at all either for the laws or for justice. In Greek two negatives only strengthen one another, provided that the second one is compound. rò díkalov justice. -Introd. Note B. (ix.).
+64 
+1.  μετὰ δώρων . fluence of bribes.
+NOTES TO PAGES 5, 6 
+• 
+they decide cases with gifts, i.e., under the in
+1.  εἰσί is understood with ἔμπειροι δέ from the previous clause. In general if a word or group of words is required with two clauses, it is inserted in the first clause and understood in the second.
+2.  OUTW. See 1 2 n.
+• 
+Page 6, 1. &v of which; the Rel. Pron. ős, 7, 8, is declined in its other cases like the Article with a rough breathing instead of τ, p. 146.
+τὰ μὲν 
+ék dè Tŵv.—Introd. Note B. (viii.). pépe. Neut. Plurals in Greek take a Singular Verb. This arose from an original use of the Neut. Plur. as a singular collective noun.
+1. ἀθάνατον. See 4, 19 n.
+Section 4. Past Imperfect of εἶναι, ή; of λύειν, ἔλυον, p. 147. Syllabic Augment, p. 147; Strong Aorist, p. 148.
+1. κατά αι, cf. 4, 12.
+• 
+1. τοῖς παρά those along the shore of the Black Sea.-Introd. Note B. (iv.). The name Euxine (hospitable) was given it to avoid the original ill-omened name of "Aĝevos (inhospitable).
+2. xаλeñ@s peрov, like Lat. aegre ferebant, were indignant at. On augment, see p. 147.
+3. Thy Tay Touρкkov aрxýv.-Introd. Note B. (iv.).
+ȧñoσróλous, the envoys of the conspirators were called Apostles, i.e. messengers.
+1.  oσovs Teidov all whom they persuaded; the suppressed antecedent of this clause is the object of ξυνάγουσιν.
+2.  oi kar' meipov those on the mainland.—Introd. Note B. (ix.). 13. Kai . . . Kaí.-Introd. Note A. (iii.).
+3.  toùs év tŷ §vvwμoơią.—Introd. Note B. (ix.).
+The Philiké Hetairia, or Association of Friends, was the successor of the Philomuse Society, which had as its object the encouragement of Greek literature; in 1815, it became a political society for the purpose of raising an insurrection against the Turks. The members, on being initiated, swore on their knees at dead of night to be faithful to their afflicted country, to labour for her regeneration, not to disclose either the secrets of the society or the name of the person who initiated them, and to put to death their nearest and dearest relations, should they be guilty of treachery.-GORDON.
+1.  οἱ μέν in contrast with τοῖς δὲ προστάταις, 1. 20. ¿Bouλevov ori gave their opinion that. Cf. 5, 10.
+2.  xp is a noun, meaning necessity. It is used (with eorí understood but never expressed) to mean it is necessary. The Past Imperf. is χρῆν (χρὴ ἦν), and the Inf. χρῆναι (χρὴ εἶναι).
+χρή is understood with κατακαίειν, κτείνειν and ἀναλαμβάνειν. See 5, 23 n.
+L 
+NOTES TO PAGES 6, 7 
+1.  τοῖς προστάταις ἦν γνώμη the leaders determined. 21. πρῶτον μέν 
+Teira.-Introd. Note A. (iv.). πόλεμον belongs to both clauses.
+65 
+ἐξάγειν ἐς τὸν 
+The provinces of Moldavia and Wallachia form the present kingdom of Roumania. The Hetairists wished the first outbreak to take place in this district because it would be easy for Russia to send troops to their assistance.
+1.  τε 
+και 
+• 
+· 
+Kaí.-Introd. Note A. (iii.).
+1.  ópíčel. See 6, 1 n.
+2.  Constantinople drew its principal supply of food from the rich alluvial plain of these provinces.
+3.  By the treaty of Bukharest, between Russia and Turkey, the Sultan had undertaken to appoint Christian governors (called Hodospars) over these provinces, and not to keep more than a small number of Turkish troops in them.
+diéTEμTE, for Augment of verbs compounded with prepositions, see p. 148.
+Page 7, 4. 8' ovv 80, is used after a parenthesis or a digression, resuming the main narrative.
+1. Após in relation to, i.e., for. 10. ἔπρασσον πρός negotiated with. Theodore Vladimiresko (so-called because he had received the Russian Order of St. Vladimir) had been a colonel in the Russian army. As he was a Wallachian landowner, he had great influence among the natives.
+2.  Georgaki (the name is the diminutive of George) was a Greek from Mount Olympus, and at this time in command of the troops at Bukharest. Caravia was captain of the garrison at Galatz.
+3.  čμalov, for Strong Aorist, see p. 149.
+тà пερì τns Evvшμoorías.-Introd. Note B. (ix.).
+Section 5. râs, p. 145; Temporal Augment, p. 147.
+1.  0, for Strong Aorist, see p. 149.
+παντὰ τὰ ἐν τῇ Μολδοβλαχίᾳ all the arrangements in Roumania.
+1.  τὸν Ὑψιλάντην στρατηγὸν προστάξαντες appointing Hypsilantes general. Participles in -as are declined like râs, and are given in the Vocabulary as adjectives.
+Prince Alexander Hypsilantes had served in the Russian Imperial Guard, and had lost an arm at the battle of Culm in 1813; after the peace of 1815 he grew weary of inaction and entered warmly into the plans of the Hetairists.
+...
+1.  ős ・ ・ åñéðave who had been put to death by the Turks on a charge of treachery. The Aorist in a subordinate clause often refers to a time which is past from the point of view of the main clause; in these cases we use the Pluperfect in English. vñó, see 5, 16 n.
+2.  & ovv. See 7, 4 n.
+5 
+66 
+NOTES TO PAGES 7, 8 
+1.  és diakoσiovs to the number of 200; a common use of ès with numerals.
+2.  óμnpovs aßov seized as hostages.
+3.  deopoîs lit. with chains, Instrum. Dat. 4, 24 n. 27. πλην oσoi àrévyov except those who had escaped. Tλn is also used as a Preposition, 6, 29.
+4.  ér' èλevbepía to secure the freedom of the people.
+ἥκει . . . μέλλει, had come intended; notice that in nounclauses introduced by or, the original tenses are retained; for instance, in the proclamation Hypsilantes said, I am come... Russia intends, therefore the Present tenses are retained, though we translate them by Past tenses. Cf. 11. 14, 16, and passim.
+At the end of the proclamation came these words: "If some desperate Turks venture to make an incursion into your territory, fear nothing; for a Great Power is ready to punish their insolence". The "Great Power" was, of course, Russia.
+Page 8, 1. Instead of taking military precautions Hypsilantes commenced operations by seizing a wealthy banker whom he accused of being hostile to the Revolution and concealing funds belonging to the Hetairia. The first accusation was not a crime and the second was false; but the banker was glad to pay the prince several thousand pounds to escape out of his hands. This act of extortion alarmed the wealthy citizens, who, afraid of being robbed by the Greeks, availed themselves of every opportunity of escaping into Russia and Austria 
+--FINLAY.
+1. ¿s eidov when they saw. For Augment, see p. 149.
+2. évóμicóv тe and they thought; re is here used as a conjunction, joining two sentences.-Introd. Note A. (i.).
+3. où pédλei was not likely; for tense, see 7, 28 n.
+4.  ékeî.-Introd. Note B. (iv.).
+5.  тà Tâν éμπóрpwv.-Introd. Note B. (ix.).
+6.  Kaì AVTOì Tò avrò eπpaσσov themselves too did the same. Cf. 5, 10 n. aurós immediately preceded by the article means same.
+7.  ékáλvov tried to prevent.
+Section 6. Tís, p. 144; rɩs, p. 146.
+1.  μerá with Acc. after; with Gen. with, 1. 22.
+Tроúßaive, for Augment, see p. 148.
+• 
+1.  εἴ τις καὶ ἄλλος . lit. if any one else also of those in the conspiracy (was loyal), i.e., was as loyal as any one.
+2.  VσTepov subsequently, as related in Sect. 12.
+3.  Tŵv EK Tηs Tepioixidos.-Introd. Note B. (ix.).
+4.  xápiri by his influence.-Instrum. Dat. 4, 24 n.
+5.  ἐν ἐλπίδι καταλύειν καὶ . . . ἀναλαβεῖν he is in hopes of over
+· 
+NOTES TO PAGES 8-10 
+67 
+throwing . . . and recovering. Notice that the Aor. Infin. does not refer to past time. See p. 150.
+1.  τῷ αὐτῷ, 1. 13 n.
+• 
+Page 9, 1. ἐν παντὶ δὴ ἀταξίας lit. in everything of disorder, i.e., in a state of utter disorder and suspicion. 8n only emphasises πâs, cf. 5, 2.
+1. Tapeixe, for Augment, see p. 149.
+2. Výkovov takes either the Gen. (as here) or the Dat..
+3.  This Sacred Battalion consisted of about 500 Greeks; their uniform was black with a cross formed of bones in front and Constantine's inscription, In hoc signo vinces.—ALISON.
+Section 7. Pres. Ind. of Toleîv, πoιâ, p. 148.
+1.  ouros eixe, with adverbs exew means to be; when matters in the camp were in this condition.
+2.  ὑπ ̓ ὀργῆς angrily.
+κρύφα αὐτοῦ without his knowledge.
+1.  Besides disavowing the Insurrection, the Czar (Alexander I.) commanded Hypsilantes "to proceed no further, but on the contrary if possible to disband the unhappy men, whom you have misled". Hypsilantes pretended that the Russian proclamation was only a blind to deceive the Turks, and that the Czar was really sending troops to support him.
+2.  orparia with an army; the Instrumental Dative is very common in military phrases, expressing the accompanying force.
+3.  ὅσα . Καραβιού, see 6, 10 η.
+4.  ônó. See 5, 16 n. τὴν τιμωρίαν ávaλaußávew to take vengeance on those who had committed the crime. The Participle with the Article is equivalent to a noun, just as an adjective with the Article is ; ó ádikýσas or ó ädikos 
+the wrong-doer.
+= 
+1.  oi μer' avrov lit. those with him, i.e., his troops.-Introd. Note B. (ix.).
+66 
+1.  TOû BOUKоUpeσríov from Bukharest. The Gen. in Greek expresses separation," from, like the Lat. Abl. of Separation. Cf. 3, 7 n. 30. Xov, for Augment, see p. 149.
+• 
+Page 10, 6. Xaßeiv to receive the governorship as the reward of his treachery. Cf. 8, 28 n.
+1.  avropolia xwpeiv to go by desertion, i.e., to desert; avropoλíą is Dat. of Manner, like Lat. Abl. of Manner.
+BOTE on condition of; &ore often introduces the terms of an agreement.
+Section 8. Past Imperf. of roleîv, éπoiovv, p. 148.
+1.  eival, Or. Obl., he said he was disloyal.
+68 
+1.  vñó, 5, 16 n.
+NOTES TO PAGES 10-12 
+Caravia and another officer butchered him in a 
+barbarous way with their sabres.
+1.  προσεχώρουν 
+· 
+joined the Turks as deserters.
+Page 11, 4. és ỏKTAKOσíovs ivás to the number of some eight hundred. Cf. 7, 23 n.
+1. édókeι To Tewрyákŋ it seemed good to Georgaki, i.e., G. determined. One of the reasons for postponing the engagement was the fact that the day was a Tuesday which is regarded as an unlucky day in the East.
+2. Kúkλw by a circuitous way.
+3. Bore with Inf. gives the result, whether it is the actual or only the probable result; with the Ind. it gives the actual result only, 4, 5; so as to cut them off and prevent them escaping.
+4.  οὕτω in this way they were likely to kill them all.
+• • 
+1.  Eppel, for Augment, see p. 147.
+2.  στάδια, the plur. of στάδιον is either στάδια οι στάδιοι, 9, 29.
+Section 9.
+1.  Caravia was always reckless, and on this occasion happened to be intoxicated.-GORDON.
+2.  70eλe... he wished the glory of the victory to belong to his men. eival with Dat. is used to express 66 belong to" or 
+"have" like Lat. est mihi liber, I have a book.
+1.  åμa rŷ éσtéρa lit. with the evening, i.e., at sunset. dua is often used as a prep. with words denoting "time". 23. inπos horse is sometimes used as a collective noun, meaning Cavalry, just as we speak of So-and-so's Horse meaning "mounted regiment". Tоs in this sense is fem.
+"the 
+1.  eidov is plur. because the "battalion" is regarded as soldiers"; so too kaì avroí in 1. 26. Verbs of sense-perception (e.g., seeing, knowing, hearing, etc.) take the Acc. and Partic. in Greek, as they may do in English, saw him advancing.
+2.  pyov action; used in Greek as we use action to denote battle. Ovμą kaì þóμŋ with spirit and confidence; Dat. of Manner. Cf. 10, 10 n.
+3.  pedλov they were on the point of leaving the village. Cf. 1. 9. Page 12, 1. oi órλîrai, viz., the troops mentioned in 11, 8. 4. Spouw, Dat. of Manner. Cf. 10, 10 n.
+4. ἔτρεπον routed them ; τοὺς ἐναντίους is understood from τοῖς ἐναντίοις.
+5. is eiπeiv 80 to speak; this phrase is used to apologise for an exaggeration; Távτas às eineîv = practically all, not literally all. The Infin. eireiv is used absolutely, i.e., without any syntactical construction with the sentence.
+NOTES TO PAGES 12, 13 
+Section 10. ovTOS, p. 147.
+69 
+1.  ταῦτα this ; οὗτος refers to what precedes, ὅδε refers to what is coming, 5, 9.
+2.  ἔτυχον παραστάντες happened to be standing near ; τυγχάνω takes the Participle where we use the Infinitive.
+3.  ὅσοι . λόχου, see 6, 10 κ.
+4.  oi δέ.-Introd. Note B. (viii.).
+5.  τῷ δ' Ὑψιλάντῃ ἀθυμία ἐνέπεσε Hypsilantes became disheartened. ταύτης τῆς μάχης, οὗτος requires the article to be used before the noun, as ode does. Cf. 4, 12 n.
+6.  T vσrepaia, sc. nμépa, on the next day. When an event is dated by the particular day, night, month or year of its occurrence, the Dat. is used without a prep., otherwise the prep. év is used.
+7.  The proclamation began, "Soldiers! I can hardly bring myself to sully that honourable and sacred name by applying it to persons such as you.
+Henceforth every bond is severed between us ; but I shall ever feel profoundly the shame of having been your chief."ALISON.
+1.  ἐσπίπτει is thrown into ; the Passive of compounds of βάλλειν throw is formed by the corresponding compounds of wirew fall, e.g., ἐκβάλλω I expel, ἐκπίπτω I am expelled; cf. ἀποκτείνω I kill, ἀποθνῄσκω I am killed.
+ai apxaí, Abstract for Concrete, the Austrian authorities.
+1.  voo lit. by disease, Instrum. Dat. 4, 24 n, he fell ill and died. Hypsilantes was kept as a prisoner until 1827, when he was released, but he died in the following year from the effects of imprisonment in unhealthy fortresses.
+Page 13, 1. ἐν goes with ἀπορίᾳ as well as with κινδύνῳ.
+1. ἐπ ̓ οἴκου homewards, ἐπ ̓ οἶκον home ; ἐπί with Acc. states where one goes; with Gen. it states the direction only.
+2. ¿dókovy seemed, édóke it seemed good; the two uses are the same as those of Lat. videri.
+3. evpeiv. See 8, 28 n.
+Section 11. φύλαξ, ἀγών, οἰκήτωρ, p. 144.
+1. τοὺς στρατιώτας is the object of ἀπολείπειν, which can be used transitively, as here, or intransitively 1. 19 (ảπodeíneiv ék tov ảyŵvos to desist from the struggle).
+2.  λaßeiv, Or. Obl., they considered that they had taken up arms. Cf. 10, 16.
+3.  Bσteρ kλétтai nodeμeîv to carry on a guerilla warfare. Cf. 4, 30. 15. ὅσα . . Τούρκων, see 6, 10 η.
+4.  Táde.-Introd. Note A. (ii.). 21. τῇ τρίτῃ ἡμέρᾳ. Cf. 12, 21 n.
+τῶν ἄλλων, masc.
+70 
+NOTES TO PAGES 13, 14 
+1.  Oárepa is a contracted form of rà êrepa, lit. the other parts, i.e., the other side.
+Page 14, 1. eveov, for uncontracted form, see p. 149.
+1. vπηрxev avrois lit. existed for them, i.e., they found a refuge. Cf. 11, 20 n.
+Section 12.
+1. éπì dúo μnvas for two months; Duration of Time is expressed by the Acc. alone or with éπí.
+2.  Téλos, as adverb, at last.
+3.  Monasteries were often used during the war as fortresses, or places to store ammunition; in some cases the books they contained were destroyed to provide paper for cartridges.
+4.  VUKTós by night. The Acc., Gen. and Dat. are all used to denote time. μέλλει μάχεσθαι τήνδε τὴν νύκτα, νυκτός, τῇδε τῇ νυκτί, he intends to fight throughout this night, by night, on this night. The Acc. implies that the fighting and the night last the same length of time; the Gen. implies that the night lasts longer than the fighting; the Dat. disregards duration altogether, and merely states that the night and the fighting occurred together. Cf. 11, 6, 12, 21.
+5.  Kýρvka a man with a flag of truce.
+6.  ädelav Toleiv to give a safe conduct to Georgaki and all the others who were there. The clause oσo παρῆσαν is equivalent to πᾶσι τοῖς ἔνδον.
+• • 
+1.  Georgaki addressed his followers thus: "Brothers, in our present circumstances, a glorious death is all we ought to wish for, and I trust there is no one here base enough to regret his life. Let us imitate those true Greeks our comrades, whose dead bodies are stretched on the fields of Dragashan and Skuleni and whose blood yet cries for vengeance. If we die like them, perhaps on some future day our countrymen will gather up our bones, and transport them to the classic land of our forefathers."-GORDON.
+2.  Túpyor the belfry.
+3.  éμmphoas having set it (the gunpowder) alight.
+4.  ap' où (8c. xpóvov) from the time when.
+5.  Two reasons are given for the failure (i.) διὰ rýv te áέvverríav, and (ii.) ὅτι οὐκ ἐνόμιζον . owing to the folly of Hypsilantes and because the inhabitants did not think, etc. It is very common in Greek to express two parallel ideas by two different syntactical constructions. Cf. 1. 16, where a noun and a rel. clause are parallel; and 11, 1, xadeπŵs kaì èv ver where an adverb and a prepositional phrase are parallel.
+NOTES TO PAGES 15, 16 
+71 
+PART II.
+SS REFER TO SONNENSCHEIN'S GREEK GRAMMAR.
+Section 13. Pass. and Mid. Pres. of λúew, Ind. λvopai, Inf. λveolai, Part. Avóuevos, § 183. Pres. Part. Act. of εἶναι, ὤν ; of λύειν, λύων ; Str. Aor. ἐλθών ; all like ἑκών, § 99, of ποιεῖν, ποιῶν, § 198.
+· • 
+• • 
+Page 15, 1. πρὶν 3. παρασκευάζονται The Middle Voice has a reflexive meaning, implying that the agent is working for or upon himself; in most cases English does not admit of this shade of meaning, and the Mid. is translated as if it was an active or neuter verb: e.g., Boúλovraι they wish (1. 7), páxeobal to fight (1.8). In some cases, however, the reflexive force is retained, παρασκευάζονται they make themselves ready; ἀμύνονται they ward of from themselves, i.e., they defend themselves.
+Ocîv before affairs in Roumania came. get ready to meet the crisis.
+1. Y. σтparηyouvros under command of Hypsilantes. The Gen. case is used Absolutely in Greek, like Lat. Abl. Abs.
+2. rà ŏvra the things that are, i.e., the truth.
+3. The Greeks were encouraged by several monks and hermits who issued from their cells and wrought on the superstition of the peasantry by visions and prophecies.
+4.  γάρ often introduces a narrative, alluded to in the previous clause. In English no corresponding conjunction is used.
+čtvɣov áπoßáνtes happened to disembark. Cf. 12, 11 n.
+1.  The Turkish armies were largely recruited from the Albanians, who enjoyed a high reputation for bravery.
+2.  és xapádpav évý pevov set an ambuscade in a ravine; cf. Lat. abdere se in silvam.
+ἐς εἴκοσι. Cf. 7, 23.
+1.  τούτων γενομένων. See l. 5.
+Page 16, 6. μédλovorav coming.
+Section 14. Pass. and Mid. Pres. of roleîv, Ind. Tolovμai, Inf. ποιεῖσθαι, Part. ποιούμενος, § 199; ὄνομα, § 32 ; γένος, § 33.
+1. οἱ ἐκ τῆς περιοικίδος Έλληνες.-Introd. Note B. (iv.).
+2. πεῖραν ποιοῦνται τοῦ τείχους make an attempt on the fort.
+3.  áμúver means to ward off, sc. Tous Toλeμious, the Mid. means to ward off for oneself, hence to defend oneself. Cf. 15, 3 n.
+4.  βουλευομένοις πρὸς deliberating with regard to.
+5.  ὥστε . ¿¿eλÕéîv on condition that the Turks should march out. Cf. 10, 10 n.
+72 
+1.  ἐπὶ τούτῳ 
+NOTES TO PAGES 16, 17 
+on this condition they guarantee their lives. 22. ὡς ἀδύνατον ν since it was impossible in any other way. The Acc. is used absolutely (instead of the Gen.) with Impersonal verbs, or Neut. adj. with ov, see 1. 29 eυ πapaoxov there being a favourable opportunity, from Impersonal ev mapéxe there is a favourable opportunity. às is often used with Partic. or Prepositional phrases, to give the motive for the action expressed by the main verb. Cf. 17, 8, 20.
+1.  vipxe their numbers were not sufficient. Cf. 14, 2 n.
+2.  See 1. 22 n.
+· 
+1.  Καλαμάταν . ἐπολιόρκουν lit. they besieged a place (χωρίον τι) Kalamata, as to its name. Καλαμάταν is in apposition to χωρίον, ὄνομά is Acc. of Respect.
+Page 17, 1. σπονδὰς ποιοῦνται 
+= 
+σπένδονται. This periphrasis with 
+= 
+ποιεῖσθαι is extremely common; cf. 1. 7 εὐχὰς ποιοῦνται εὔχονται; 1. 29 λείαν ἐποιοῦντο = ελῄζοντο ; 1. 30 φυγὴν ἐποιοῦντο = ἔφευγον, and other instances in Vocab. 8.v. Toleiv. The Passive is formed by yiyveobai, e.g., ἀρχὴν ποιοῦνται τοῦ πολέμου they begin the war, ἀρχὴ τοῦ πολέμου yiyverai the war is begun. Cf. 15, 10.
+1. BOTE. See 16, 17 n.
+2. Tŷ Túxn by their good fortune. Instrum. Dat.
+"On the 5th of April, 1821, the Greeks sang their first thanks to God for victory. The ceremony was performed on the banks of the torrent that flows by Kalamata. Twenty-four priests officiated and five thousand armed men stood round. Never was a solemn service of the Orthodox Church celebrated with greater fervour, never did hearts overflow with sincerer devotion to Heaven, nor with warmer gratitude to their church and their God. Patriotic tears poured down the cheeks of rude warriors, and ruthless brigands sobbed like children. All present felt that the event formed an era in the history of their nation."-FINLAY.
+1. às airíovs õvras as being the authors.
+2.  Kará in accordance with.
+3.  ὅτι . . . σελήνη in apposition to λόγος. We might omit ὅτι and put inverted commas.
+Section 15. Pass. and Mid. Ind. Past Imperf. of λvew, éλvóμny, § 183; of ποιεῖν, ἐποιούμην, § 199; Str. Aor. Mid. of γίγνεσθαι, Ind. ἐγενόμην, Inf. γενέσθαι, Part. γενόμενος.
+1.  τῶν 
+• 
+yevouévov of what had happened; the commonest Str. Aor. Mid. are ᾐσθόμην (αἰσθάνομαι perceive), ἀφικόμην (ἀφικνούμαι arrive), ἐπυθόμην (πυνθάνομαι ascertain), έτραπόμην (τρέπομαι turn), ὑπεσχόμην (ὑπισχνούμαι promise).
+1.  Many of these Mussulmans were Greeks by origin; their fore
+NOTES TO PAGES 17-19 
+73 
+fathers had adopted the religion of Mahomet to avoid having to send their children as tribute to Constantinople.
+1.  λeíav éπoloûvтo they plundered. Cf. 17, 1 n.
+Page 18, 1. où διὰ μakpov (sc. xpóvov) lit. not at a great interval of time, i.e., soon.
+1. ἔχοντες 
+· 
+.. having the events at Kalamata as examples of all that they too were likely to suffer.
+1. The Greeks at Patras issued a proclamation containing merely these emphatic words,-Peace to the Christians! Respect to the Consuls! Death to the Turks! 
+Lord Byron has translated one of their battle-songs, "Sons of the Greeks, arise!" 
+Section 16. Act. Fut. of Xue, Ind. λvow, Inf. Xvoew, Part. Xvowv, § 181. πόλις, § 37. ευγενής, § 100. ἐκεῖνος, -η, -ο, § 142.
+1.  κai čтi πрóтepov or a little before; xaí corrects the previous statement.
+2.  TOUS Tрокpírovs the Primates; these were Greek officials, appointed by the Turks to act as local magistrates in unimportant cases, and to collect the taxes.
+3.  δι' ὧν . . . ἐπράσσοντο by whose agency they raised the taxes. 16. ås BovλevσovTes to deliberate; the Fut. Partic. expresses purpose as in Latin.
+• 
+• • 
+ἐν ἀξιώματι ἦσαν ὑπό were held in honour by. Cf. 5, 16. 18. no@ávovтo... lit. perceived the Greeks that they were preparing, i.e., perceived that the Greeks were preparing.
+1.  ἐσκόπουν ὅπως . . . κωλύσουσι considered how they should prevent. Ind. Question; the tense and mood of the original question "How shall we prevent?" are retained, just as is the case with ori. Cf. 7, 28 n.
+Anvel, Instrum. Dat., by the taking.
+1.  οὐ προυχώρει 
+• 
+matters did not proceed as they wished. 28. ἄριστα ἕξει τὰ πράγματα matters would be best; ἄριστα is an adverb. Cf. 9, 13 n.
+1.  For omission of conjunction see Introd. Note A. (ii.).
+Page 19, 2. Ek πapaσкevĤs by arrangement.
+1. προσεποιοῦντο 
+they pretended (a) that a letter had come ..., 
+and (b) that he advised them.
+• 
+For the two different constructions 
+(i.) Acc. and Inf. (ii.) or clause, see 14, 28 n.
+1. μελλόντων 
+• 
+since the government intended to kill them all.
+oi év ápxaîs = ai ȧpxaí, 12, 27.
+1.  ἐπ ̓ οἴκου means in the direction of home, homewards 1. 1 ἐπὶ τῆς πόλεως: ἐπ ̓ οἶκον 1. 6 means home, implying that you get there. Cf. 13, 2 n.
+74 
+NOTES TO PAGES 19-21 
+Section 17. Act. Weak Aor. of λveiv, Ind. ëλvoa, Inf. Xvoai, Part. λύσας, § 182. βασιλεύς, § 37. μέγας, § 105.
+1.  διὰ τὸ . . . ἔχειν owing to his regarding all alike with suspicion. The Article with the Infin. forms a noun-equivalent. It can be used in any case (Dat. 1. 26; Nom. 20, 4) and is especially common after prepositions. The Infin. may have a subject, or object (as rávτas), and may be qualified by any adverbs (as ouoíws) or adverb-equivalents (as év vπovía), just as is the case with any other use of the Infin.
+2.  μéya тi πрâyμa πpáşavra lit. having done some great deed, i.e., by some violent measure.
+3.  τῷ Evλλaßeiv by arresting them. Cf. 1. 20 n.
+• 
+1.  The Chief Dragoman and Secretary were important Turkish officials.
+Page 20, 4. rò μǹ vñakovew lit. the not-obeying, i.e., disobedience. See 19, 20 n.
+1. βασιλέως 
+= 
+Σουλτάνου.
+1.  ròv yàp Baoiλéa, Or. Obl. Cf. 10, 16.
+2.  διὰ To Tηv éoprǹv äyeɩ because of their keeping the festival. See 19, 20 n. Gregory was arrested on Easter Eve.
+3.  čruxov ronoovres happened to be going to celebrate. Cf. 15, 11. 19. Sultan Mahmud II. was called "the Butcher" by the Greeks after this murder. Gregory was 82 years old at the time of his execution. There is no reason to suppose that he was inculpated in the conspiracy. At all events he had solemnly excommunicated Hypsilantes when the news of the insurrection in Roumania reached Constantinople.
+Section 18. γλυκύς, § 102. πολύς, § 105.
+1.  The feelings with which the Jews and Greeks regarded one another may be illustrated by this extract from Gordon: "A band of Jews attended the Pasha's camp voluntarily in the capacity of executioners, allured merely by the pleasure of butchering with clubs the Greek prisoners. One of these execrable savages afterwards boasted that in a single day he had with his own hands slaughtered sixty-four victims.
+"" 
+Page 21, 1. Greek priests wear beards, while other Greeks do not, hence it was easy to recognise the body.
+1. ὥσπερ θείᾳ τύχῃ providentially. 13. οὐ χαλεπόν 
+suffered.
+it is not hard to imagine all that the Greeks 
+Section 19. Act. Perf. of Xúew, Ind. λevka, Plup. λeλúкn, Inf. λeλvkévaι, Part. λeλvkós, § 182. Some Perfects end in Oa, ya, da, e.g., ἐλήλυθα (ἔρχομαι come), πέφευγα (φεύγω fee), εἴληφα (λαμβάνω take).
+1.  καταλαμβάνουσι 
+· 
+peλovra find that the people were on the 
+NOTES TO PAGES 21-23 
+75 
+point of holding an assembly. Verbs of finding and sense-perception (perceiving, seeing, knowing) take the Participle instead of the Infinitive. Cf. 11, 25 n.
+1.  is Telow to persuade. Cf. 18, 16 n.
+2.  Teixiopara. The fortresses in the Peloponnese still held by the Turks were Nauplia, Navarino, Modon, Coron, Monemvasia, Patras and Tripolitza.
+Page 22, 4. τοὺς νησιώτας καὶ ὅσοι 
+eioiv. Cf. 14, 28 n. 7. ἀπ' αὐτῶν = ἀπὸ τῶν κινδύνων which will result there from. 8. ὅσα . ἡμαρτήκασι the crimes of the Turks; so ὅσα πεπόνθαμεν 
+our sufferings.
+1.  πάντων ὧν ἐπεπόνθεσαν for all they had suffered. ὧν is attracted into the case of its Antecedent návrov; this attraction occurs when the Relative Pron. would naturally be in the Acc. and its Antecedent is in the Gen. or Dat.
+21 n.
+1.  ἠσθάνοντο 
+ὄντας. Cf. 21, 
+Section 20. Fut. Mid. of Xve, Ind. Xvooμai, Inf. λvoeσbai, Part. λυσόμενος, § 183; of είναι, Ind. ἔσομαι, Inf. ἔσεσθαι, Part. ἐσόμενος, § 266. vaus § 49 (14); voûs § 26.
+1.  The inhabitants of Psara, Spetza, and Hydra supplied sailors to man the Sultan's fleet, as well as paying a small tribute.
+2.  τὰ δὲ ἄλλα . . in other respects they were free citizens.
+3.  During the wars which followed the French Revolution, the crews often doubled their capital by carrying grain from the Bosphorus to the blockaded towns.
+Page 23, 4. dógav Acc. Abs. from Impersonal dokeî it seems good :— since they had determined. Cf. 16, 22 n.
+• 
+• 
+• 
+1. ὅπως ξυλλήψονται to arrest. 9. ἐπιμελησόμενοι ὅπως βοήθειαν to arrange to prevent the Sultan sending help. Verbs of effort, e.g., erueλéîodai, πpáσσeV ἐπιμελεῖσθαι, πράσσειν take pains, pulárσeolau take precautions, take ones with Fut. Ind. ἐπιμελησόμενοι is in the Nom. by sense-construction, ἄριστον εφαίνετο 
+Tλeiv being equivalent to they determined to sail.
+1.  ἐφαίνοντο παρασκευαζόμενοι were clearly making ready; φαίνομαι εἶναι I appear to be ; φαίνομαι ὢν I clearly am.
+Section 21. Weak Aor. Mid. of Ave, Ind. Avσáμny, Inf. λvoaodai, Part. Avoάuevos, § 183.
+χείρ § 49 (24). ἀργυρους, § 93.
+1.  The Turkish guns had a longer range than those of the Greeks, which made the latter unwilling to approach the man-of-war. On the other hand the Turkish gunners were so erratic that Lord Byron 
+76 
+NOTES TO PAGES 23-26 
+remarked on one occasion that they would be more formidable if they did not take aim.
+1.  γνώμην ἐποιήσατο proposed.
+Page 24, 3. éyéμoav kλŋparidwv they filled with brushwood. 10. és rò... getting into the small boat they rowed away.
+1.  où yàp hv for it was not possible.
+• 
+1.  διὰ τὸ πpoσéxew owing to the enemy paying attention. Cf. 19, 20 n. On several other occasions Canaris repeated the exploit here described.
+2.  The Greeks excused these murders on the ground that they were avenging Gregory's execution.
+Section 22. Pass. Weak Aor. of λvew, Ind. ‹λúðŋy, Inf. λvôĥvai, Part. λυθείς, §§ 183, 108 (3); Fut. Ind. λυθήσομαι, Ιnf. λυθήσεσθαι, Part. λυθησόμενος, § 183.
+1.  TOUTWV.-Introd. Note A. (ii.).
+2.  Demetrius Hypsilantes is thus described by Gordon: "Nature had favoured him more in mind than in his corporeal frame, for his diminutive stature, bald head, awkward carriage, and indistinct utterance, were ill-calculated to win the opinions of those who beheld him. On the other hand it was difficult to know without esteeming him, for even his enemies were forced to confess, that to ardent patriotism he united courage, integrity and humanity, disregarded the allurements of pleasure, and had much goodness of heart, with a steadiness of purpose which at times bordered upon obstinacy." 
+"Colokotrones, like his father, had been a clepht. Tall and athletic, with a profusion of black hair and expressive features, alternately lighted up with boisterous gaiety, or darkened by bursts of passion : among the soldiers he seemed born to command, having just the manners and bearing calculated to gain their confidence." 
+Page 25, 8. v. Cf. 22, 13 n.
+1.  τῶν παρόδων 
+ἐσκομισθήσεται to keep watch on the passes to prevent supplies being sent in. Cf. 23, 9 n.
+1.  The camp was situated at Valtetzi, several miles south of Tripolitza.
+2.  The moral effect of this victory in encouraging the Greeks was out of all proportion to the losses actually inflicted on the Turks, which amounted to about 400 men.
+Section 23. ȧvýp, § 49 (1); yvvý, § 49 (5).
+Page 26, 14. hy it was possible. Cf. 24, 13.
+• 
+1.  εἴ τινες · if any were known to them, i.e., they sent to any of those inside whom they knew, 
+NOTES TO PAGES 26, 27 
+77 
+1.  ἐπὶ τῷ 16, 19 n.
+• 
+δέxeobai on condition of receiving. Cf. 19, 20 n; 
+1.  The report that a Turkish army was coming turned out to be false.
+Section 24. Pass. and Mid. Perf. Ind. of Xúeiv, δέλvpai, Plup. ἐλελύμην, Ιnf. λελύσθαι, Part, λελυμένος, § 183.
+Page 27, 4. év TO NEOKáσTрo. Navarino had capitulated on 19th Aug. and a dispute arose about searching the Turkish women for jewels which they were supposed to have concealed. "Women wounded with musket balls and sabre cuts rushed to the sea seeking to escape and were deliberately shot. Greeks seized infants from their mothers' breasts and dashed them against the rocks. Children, three and four years old, were hurled living into the sea and left to drown. When the massacre was ended, the dead bodies washed ashore or piled on the beach threatened to cause a pestilence. Phrantzes (a Greek priest) who records these atrocities of his countrymen with shame and indignation, himself hired men to burn the bodies of the victims with the wrecks of some vessels in the harbour."-FINLAY.
+1.  Colokotrones records in his Memoirs that when he rode into the town his horse "from the walls to the palace never touched the earth,” owing to the accumulation of dead bodies.
+2.  τοὺς ἔνδον ἀποκτείνοντες ἐπέπαυντο, lit. murdering the inhabitants they had then desisted.
+3.  εἴ τι παρελέλειπτο 
+they plundered all that had been left. Some of the richest families in Greece to-day owe the foundation of their fortunes to the spoil of Tripolitza.
+1.  "After the Greeks had been in possession of the city for fortyeight hours, they deliberately collected together about 2,000 persons of every age and sex, but principally women and children, and led them to a ravine in the nearest mountain, where they murdered every soul. . . Some prisoners were spared for a short time to bury the bodies of their slaughtered countrymen, which were putrefying by thousands in almost every house and garden. Even this precaution was too long neglected. The air was already tainted with a deadly miasma and a terrible epidemic soon broke out among the Greeks."-FINLAY.
+78 
+NOTES TO PAGES 29, 30 
+PART III.
+Section 25. Act. Subj. Pres. of eivai, &, § 266; of λúeiv, dúw, § 181 ; Wk. Aor., λύσω, § 182; Str. Aor. of πάσχειν, πάθω ; Pres. of ποιεῖν, ποιῶ, § 198.
+Regular Compar. of Adj., §§ 110, 111, 113 and Adverbs, § 173.
+Page 29, 1. áμа тô hρi áрxoμένe with the beginning of the spring (see cap). The Partic. is used as in Latin ante urbem conditam: Oépos summer includes spring and autumn, and is used of the whole period during which military operations were carried on in ancient times.
+· 
+· 
+1. ὅπως ἐσαγάγωσιν in order to introduce; όπως (or iva) in order that with the Subj. expresses purpose. The Aor. in the Subj. Optat. and Imperat. moods is not a past tense: the difference between it and the present is not a difference in time but in kind of action ; the present regards the action as continuing, the Aorist regards it simply as occurring. Cf. p. 150.
+2. Twν výσwν Kрarnbeir@v, Gen. Abs. expressing a condition, if the islands were conquered.
+3. ἐπικινδυνοτάτην εἶχον. See 5, 11 κ.
+4.  εὐτυχήσαντες. See Sect. 21.
+5.  avrov than they were. The Gen. of Comparison is used like the Latin Abl. of Comparison; it is a Gen. of Separation, laxuρÓTEρOL aurav meaning stronger starting from them.
+6.  Tois nãσi Evrорwтárny excellently provided with everything. "Celebrated for its fertility and the enchanting aspect of its gardens, Chios carried on a brisk trade in silk and fruit; from thence Constantinople was supplied with oranges, lemons and citrons; but the most valuable production of the country is gum mastic, a substance highly valued by Eastern ladies, who amuse their indolence by chewing it, deriving from that practice as much gratification as their male relations enjoy by inhaling the fumes of tobacco."-GORDON.
+7.  poßoúμevo un пábwσi fearing that they would suffer. The object clauses after words of fearing are introduced by μn lest, followed by the subj.
+8.  Antonius Bournia had previously served in the French army. 20. ἐποτρύνωσι. See l. 3 n.
+Page 30, 9. etre perexwo whether they should take part in the war. The subj. is used in Deliberative Questions, as in Latin.
+1.  devov v there was danger lest. Cf. 29, 16 n.
+Section 26. Irreg. Compar. of Adj., §§ 117-119 and Adv., § 175. βελτίων, § 120.
+1.  ως is used for οὕτως in the expressions καὶ ὥs even 80, οὐδ ̓ ὦς not 
+even 80.
+NOTES TO PAGES 30-33 
+79 
+1.  or, or as (1. 21), is used with superlatives of adj. or adv. meaning as much as possible, like Latin quam.
+2.  πрiv 8 égeλeiv before they captured it.
+Page 31, 3. Told by much, i.e., far more powerful. 5. ἀσθενέστεροι ἢ ὥστε lit. weaker than so as to weak to defend themselves.
+1.  ǹ as.
+• 
+., i.e., too 
+1.  Karà xiλious a thousand at a time; Distributive use of kará. 14. is eiπeiv. See 12, 6 n.
+2.  éπì dovλeia for slavery, i.e., to be slaves.
+It is said that out of 100,000 inhabitants of Chios, nearly a third was massacred, and nearly the half enslaved, only 1,800 were still living on the island in August, 1822.
+Section 27. Act. Optat. Pres. of Ave, Avoyu, § 181; Str. Aor. οἱ πάσχειν, πάθοιμι. Numerals, § 122. εἰς, δύο, τρεῖς, τέσσαρες, of § 123.
+1.  OUтws πρatav fared thus. рáσσew, like "do" in English, with adv. means to fare.
+2.  The Albanian Christians, who lived at Souli, had fought on the side of Ali Pasha of Janina; when Ali was killed (Feb., 1822), they had continued the war with some success under Marcus Botzares, but were now being besieged in the Castle of Kiapha, which is the Acropolis of Souli.
+3.  Tapéxou. After an historic tense (Bouλero) the Optative may be used (instead of the Subj.) in final clauses, and with verbs of fearing.
+4.  γνώμῃ 
+inferior to no one in judgment; ovdevós is Gen. of Compar. See 29, 13 n.
+The corps, 
+Page 32, 6. The Philhellenes were officers from various European countries, who had volunteered for service in Greece. consisting of about 100 men, was formed to show the Greeks the value of discipline.
+1. yévos by race. Acc. of Respect. Cf. 16, 30.
+2.  Gogos had greatly distinguished himself in the previous year by repulsing a Turkish attack on Peta.
+3.  φοβούμενος μή EXOLEV. See 31, 25 n.
+• 
+1.  ei. . . κaðégovor if they should control the administration of affairs.
+2.  oi δέ the Turks. Cf. Introd. Note B. (viii.).
+Section 28. Act. Optat. Weak Aor. of Xúew, Xvoa, § 182.
+• 
+Page 33, 9. τὸ πολύ ἐξέλθοιεν bear the brunt of the attack.
+fearing that they would no longer effect anything.
+1.  δείσας 
+80 
+NOTES TO PAGES 33-36 
+1.  Most of the Turkish army had been recruited in Albania.
+2.  When two Rel. clauses, referring to the same antecedent (here Aópov), stand side by side, and the second Relative would be in a different case from the first (here first Rel. is ov and second would be ds), the second Rel. is either omitted (as here), or replaced by a Personal Pronoun. Cf. St. Matt. iii. 12, whose fan is in his hand, and he (not who) will throughly purge his floor.
+3.  ὡς σωτηρίας . as each group had hope of safety.
+Page 34, 1. roîs de λonoîs with the rest. Cf. 9, 19 n.
+1. ovdeμiâs éláσowv less than none, i.e., worse than any of the calamities in the war.
+2.  The remnant of the Philhellenes was disbanded shortly afterwards. The following incident is related by Gordon: "At noon on 16th July, as Mavrocordato sat at dinner with his suite at Langada, one of the Greek commanders, examining the shoulder-blade of a sheep according to a method of divination practised in the East, declared that their friends had suffered a bloody defeat; this caused some mirth at the seer's expense, until a horseman, while they were still at table, brought news of the battle of Peta". Two days after the battle Gogos went over to the enemy. Some of the Souliotes continued to fight on the Greek side under M. Botzares. See Sect. 35.
+3.  Corcyra (Corfu) was neutral territory, being under the control of an English High Commissioner.
+Section 29.
+1.  There were no houses in Salamis for the accommodation of these refugees, and the landowners showed their patriotism by exacting rent for the privilege of sleeping under an olive-tree.
+Page 35, 5. Bpaxéa eixov had their supplies short, i.e., were short of supplies. Cf. 5, 11 n.
+1. ὅπερ id quod.
+2.  oσov où almost, Lat. modo non.
+3.  äλdoi äλda ëλeyov, Lat. alius alia dicebant.
+Section 30. yw, σú, § 128. Act. Imperat. Mood of eivai, lobi, § 266; of λύειν, Pres. λνε, § 181 ; of ποιεῖν, ποίει, § 198; Wk. Aor. of λύειν, λύσον, § 182; Str. Aor. of πάσχειν, πάθε.
+1.  palóvrov let them learn. The 3rd Pers. Plur. of Imperatives is the same in form as the Gen. Plur. of the Participle.
+2.  ĕxovraι kaì ai vñσo the islands too are in their hands; the Present is used graphically for the Future.
+Page 36, 1. τίνα ἐλπίδα ἔχοντες 
+.
+• 
+with what hope or with what 
+NOTES TO PAGES 36-38 
+81 
+purpose? The interrogative rís; who? is declined like the indefinite Tis any one, but accented differently, § 151.
+1. πôs où ßλáßŋ (ẻorí); how is it not a loss? i.e., surely it is injurious.
+2. voμion undeís let no one suppose. Prohibitions are expressed by un (or compounds μndeis, unkéti, k.T.λ.) with (i.) the Aor. Subj. or (ii.) the Pres. Imperat. (1. 24).
+3.  puλáoowμev let us guard. The Subj. supplies the missing 1st Pers. Plur. of the Imperat. as in Latin.
+4.  ávax@povσiv, Participle, when they retreat.
+5.  πάντων μάλιστα most of all.
+6.  πάσχειν = βλάπτεσθαι.
+7.  μηκέτι . . . ἔστε do not be alarmed any longer, 1. 5 n. 25. πρὸς ὑμῶν in your favour.
+8.  Evμßýσerai ημiv will happen to us, i.e., will be achieved by us.
+Section 31. Reflex. Pronouns éavróv, opeîs, § 134; Pass. and Mid. Subj. Pres. of λύειν, λύωμαι, § 183 ; of ποιεῖν, ποιῶμαι, § 199 ; Str. Aor. Μid. of γίγνεσθαι, γένωμαι.
+= 
+Page 37, 1. rà opérepa avrâv sua, their own property. opérepos is used (i.) as a Direct Reflexive, referring to the subject of the verb in its own clause, or (ii.) as an Indirect Reflexive, used in a Subordinate clause, and referring to the Subject of the main verb. If avrov is added, it is a Direct Reflexive only.
+1. τοὺς ἑαυτοῦ his own men.
+2.  raúry there.
+3.  opas is an Indirect Reflexive, used in a Subordinate clause and referring to the Subject of the main verb.
+4.  οὐ πολὺς 
+there was not much time and Colokotrones arrived, i.e., it was not long before C. arrived.
+1.  τολμηρότεροι ἑαυτῶν γενόμενοι becoming braver than themselves; a common way in Greek of expressing their courage increased.
+2.  oi ek twv μereάpwv, we should say those on the hills; Greek often accommodates the prepos. to the sense of motion expressed in the verb the men came down from the hills.
+3.  ἀσφάλεια τῆς ἐξόδου come away in safety.
+that Hypsilantes and his men might 
+Page 38, 2. On the second occasion, one of the Greeks happened to be asleep when his companions evacuated the fort, and was accidentally left behind. Awakened by the noise of the Turks rushing in to plunder, he seized a large copper cauldron, and, putting it over his head to conceal his features, walked boldly out. The Turks, thinking he was one of themselves carrying off loot, let him pass with a few jokes at his ridiculous appearance.-TRICOUPI.
+6 
+82 
+NOTES TO PAGES 38-40 
+Section 32. doris, § 162. Wk. Aor. Subj. of λúeiv, Pass. λvbw, Mid. λύσωμαι, § 183.
+1. προσεδέχοντο should be προσδεχόμενοι, corresponding with φυλάσσοντες, but such slight irregularities are very common. Cf. ἔμελλε in 1. 23.
+2. The Turkish fleet which should have brought supplies sailed away to Patras owing to the Admiral's jealousy of Dramali.
+• 
+1.  τὰ τῶν πολεμίων . seeing the affairs of the enemy in what state they are, i.e., seeing in what state the enemy are.
+For the order of words, by which rà râv Toλeμíov is made the Object of idóvres instead of being placed in the dependent clause as Subject, compare St. Mark i. 24, I know thee who thou art. oris introduces an Indirect Question ; the Direct Question was ἐν τίνι ἐστὶ τὰ τῶν πολεμίων ; in what state are the enemy's affairs? Greek retains the original tense (éori), just as it does in or clauses. See 7, 28 n.
+Dramali's difficulties were much increased owing to the season being singularly dry. Disease broke out among his men, who were living mainly on green grapes and unripe melons.
+1.  οἵτινες 
+ποιήσονται to make an ambuscade : ὅστις with Fut.
+Indic. expresses purpose.
+1.  τὰ χαλεπώτατα . the most difficult points in the pass.
+2.  ποιήσωνται 
+• 
+• 
+κρατήσειαν, after an historic tense, όπως may take the Subj. (29, 3 n.) or the Optat. (31, 25 n.); occasionally, as here, both are used: there is no difference in meaning.
+1.  hy it was possible.
+Page 39, 5. oжоi тpáñwvrai where to turn; Delib. Subj., see 30, 
+9 n.
+και 
+• • 
+καί 
+• 
+• 
+both . . . and.
+Section 33.
+1.  ἰδὼν 
+2.  τοὐναντίον 
+guarding.
+• 
+πрáyμara seeing the state of affairs. Cf. 9, 13 n.
+the opposite way to that which the enemy were 
+1.  oirives since they; ooris, besides being an Indirect Interrogative Pronoun, is used (i.) to express cause, as here; (ii.) with Fut. Ind. to express purpose, 38, 14 n.; and (iii.) as an Indefinite Rel. Pron. meaning whoever, 1. 19.
+2.  το πολύ 
+= 
+oi rooi the majority.
+Page 40, 5. The state of these fugitives is thus described by Gordon : "The famishing soldiers, after eating all their horses, existed on the flesh of their dead comrades, and even fought over their graves", 
+NOTES TO PAGES 40-43 
+83 
+Section 34. Pass. and Mid. Optat. Pres. of Xúeiv, Avoiμnv, § 183; οι ποιεῖν, ποιοίμην, § 199; Str. Aor. Mid. of γίγνεσθαι, γενοίμην.
+1.  These Albanians were Christians, serving as mercenaries to the Turks. They spoke the same dialect and wore the same dress as M. Botzares and his Souliotes.
+2.  For M. Botzares, see 31, 24 n.
+3.  πεῖραν ποιεῖσθαι, see 16, 9 η.
+4.  ἂν ἐπιφέροιντο they would attack; ἂν gives to the Optative s Potential sense, expressed in English by would, might or could. Page 41, 7. öпоi тρáπото where to turn; after an historic tense, the Optat. may be substituted for the Delib. Subj. in Indirect Questions. The original question was roî rparwμela; where are we to turn? Cf. 39, 5.
+Section 35. Pass. and Mid. Imperat. Pres. of λúeiv, λvov; Wk. Aor. Mid. λῦσαι ; Wk. Aor. Pass. λύθητι, § 183 ; Str. Aor. Mid. of γίγνεσθαι, γένου ; Pres. of ποιεῖν, ποιοῦ, § 199.
+1.  avrov on the spot.
+Page 42, 2. oirives since they. Cf. 39, 17 n.
+1.  μn éкπλaynτe do not be alarmed. See 36, 5 n.
+2.  πλήθει ελάσσους inferior in numbers.
+3.  un avopeious ovo if we are not brave; the Neg. is μn (not oỷ), because the Participle expresses a condition.
+4.  πρὸς ἡμῶν on our side. Cf. 36, 25.
+5.  Teρì rλeiorov moɩîode, lit. regard above very much, i.e., regard as of the greatest importance.
+Section 36. Optat. Pres. of eivai, einv, § 266; Optat. Wk. Aor. Ρass. οἱ λύειν, λυθείην, Μid. λυσαίμην, Fut. λυσοίμην, § 183.
+1.  ei Bovλoμένo poí èori, lit. whether it is to me being willing, i.e., whether I am willing; compare Lat. quibus bellum volentibus erat.
+2.  δέxeσbai Tŷ móλei admit into the city; the Dat. Tóλe is Instrumental, literally, receive with the city; the Instrum. Abl. in Lat. is used similarly with recipere.
+3.  ǎoμevos âv dekaiμŋv I would gladly admit him: we translate the predicated Adjective douevos by an Adverb. Cf. Lat. primus hoc feci, I did it first, and reλevraîos, 35, 21.
+4.  após in answer to.
+Page 43, 2. Tepì râv 'Eλλŋvikov with regard to the Greek War; τὰ  ̔Ελληνικά is the subject of μέλλει. See 38, 10 η.
+1. Karapaivoivтo are in sight. In a clause introduced by ori (that), the Optat. may be substituted for the original Indicative, if the tense 
+84 
+NOTES TO PAGES 43, 44 
+of the main verb is historic (here hλ0). Notice that though the mood is altered, the tense remains the same; the original message was oi Τοῦρκοι καταφαίνονται. Cf. 7, 28 η.
+1. εἰ ἐλπίζοιεν whether they hoped; ἐλπίζοιεν in the original question was ἐλπίζουσι.
+2.  és rà μádiora in the highest degree. 13. εἶμεν 
+φοβοίμεθα .
+εἴη 
+• 
+ἀναγκασθεῖμεν 
+What were these words in the original statement ? 
+1.  Bovλóuevos if you are willing.
+2.  οὐκ ἴδιον ..the lead he had was not his own.
+ἔχοι.
+Cf. 5, 11 n.
+1.  βουλεύσοιτο, he actually said βουλεύσομαι I'll think about it.
+2.  or sometimes introduces the original words, and is represented 
+in English by inverted commas.
+Toù oivov, Partitive Gen. some wine.
+• 
+1.  ξυνενέγκοι may everything turn out as we wish. The Optat. by itself in a Principal Sentence expresses a wish; hence its 
+name.
+: 
+The Turks subsequently advanced to Anatolicon, a small town situated in the lagoons, about five miles west of Messalonghi. The inhabitants had been accustomed to get their supplies of drinkingwater from the mainland, as there were no springs on the island of this the Turks were aware, and therefore expected to force it to surrender quickly. A Turkish shell, however, happened to fall on the Church of St. Michael, and, breaking through the pavement, disclosed a spring, which not only supplied sufficient water, but encouraged the people to think that a miracle had been performed on their behalf. After about a month the Turks abandoned the siege.
+PART IV.
+Section 37. ripâv, §§ 196, 197.
+Page 44, 2. Tapà yváμny contrary to expectation.
+1. ὅπερ 
+which no one would have believed, if he had been told, before it happened. av is used with the Past Tenses of the Indic. in 
+a Potential sense, expressing might have, would have, could have.
+Cf. 40, 18 n.
+β. τὰ μέν 
+times.
+• 
+Tà de partly.
+partly, or sometimes 
+• • • 
+at other 
+NOTES TO PAGES 44, 45 
+85 
+1.  As an instance of Byron's energy, the following story may be quoted. When he was at Cephalonia, a number of workmen engaged in excavating were buried by the fall of a mass of earth. Byron heard of the accident while at dinner, and rushing to the place seized a spade and by his example stimulated the panic-stricken onlookers to set to work. The result was that all the workmen were rescued.
+2.  The Ionian islands, being under the protection of England, were the chief place of refuge for those Greeks who had been driven from their homes by the Turks. Cf. 34, 18 n.
+3.  âs av vaûs whatever ships they had. av, joined to Rel. pronouns or conjunctions, and followed by the Subjunctive, gives an Indefinite Sense, expressed in English by ever.
+Page 45, 7. On 30th December Byron and Count Gamba (an Italian) with their baggage and a large sum of money set sail in separate ships. Byron's ship fell in with a Turkish frigate, but succeeded in getting away to some rocky islands called Scrofes, where Byron concealed himself in a cave. Gamba and his ship were captured, but by a curious coincidence the captain of the Turkish frigate had once been saved from death by the Greek skipper, and, in gratitude for this, he pretended that he saw nothing suspicious about the vessel, and let it continue its voyage.
+Section 38. v, Xpĥodai, § 232. Contracted Futures, §§ 235, 1, 236, 237 (i.).
+1.  See Sections 34, 35.
+2.  οὔτε ὅθεν κομιοῦνται nor having whence they shall get rations, i.e., not being able to get rations.
+3.  čσTIV OTE sometimes. Cf. 1. 25. čσri in some places.
+4.  The disorder culminated in the following incident: A Souliote, noted for his bravery, came to the armoury with a young son of M. Botzares, and, having no written permission to enter, was stopped by the sentry. He persisted in going in, and the officer on guard ordered him to be arrested; a quarrel ensued, and the Souliote, having received a blow, killed the officer on the spot. In an instant alarm pervaded the town: the Souliotes rose to arms, threatening to storm the armoury and even Byron's house, if their countryman, who had been apprehended, was not set at liberty. The riot was at length appeased, but Byron declared that he would return to the Ionian islands if the Souliotes did not leave Messalonghi.—GORDON.
+Γρασσεν ὅπως 
+1.  ἔπρ 
+• 
+took steps to make the place secure. Verbs 
+of Effort take oπws with Fut. Indic. Cf. 23, 9 n.
+1.  oux egovo oros will not be able to. Cf. 1. 13 n.
+2.  eis is used emphatically with Superlatives, this man of all others, like Lat. unus.
+86 
+NOTES TO PAGES 45-47 
+1.  tŵv ka✪ ¿avróv of his contemporaries.
+On 9th April Byron went out to ride near the town and was overtaken by a heavy shower, and returned home in a boat. Shortly afterwards he complained of fever: the doctors prescribed bleeding, but he refused, saying, “I will drink all your medicines, but not one drop of my blood will I shed. All of it shall be shed on the field of battle." Delirium came on, then stupor, and at six o'clock in the afternoon of Easter Monday (19th April) at the instant of an awful thunderstorm Byron expired.
+His coffin was laid by the side of the grave of M. Botzares, but as he expressed a wish to be buried in the tomb of his ancestors (at Hucknall Torkard, near Nottingham), the body was removed to England, and his heart interred at Messalonghi.
+Section 39. dnλoûv, §§ 200, 201.
+Page 46, 10. τὰ ἑαυτῶν regarding only their own interests. 14. rois Xpημaoi from lack of money. Instrum. Dat.
+1.  oơa av δέŋ whatever was necessary. See 44, 22 n.
+2.  A committee was formed in London, including Jeremy Bentham, Joseph Hume and T. Gordon (the historian of the war), and a loan amounting to £300,000 was raised. The security was very bad, and, in fact, the interest was never paid, but by a fortunate coincidence for Greek liberty, a mania for every kind of wild speculation had just then seized English capitalists.
+3.  A talent was a sum of money worth 6,000 drachmæ or £210 in English money. A drachma = a franc.
+4.  öσa λáßolev whatever money they got; after an historic tense (édarávwv), the Rel. followed by the Optat. is used in an Indefinite Sense. After a Primary tense, this would be ora âv λáßwσi. Cf. 1. 17.
+Page 47, 1. ek toû roloúrov, by such conduct.
+"Every man of consideration in his own imagination wanted to place himself at the head of a band of armed men, and hundreds of civilians paraded the streets of Nauplia with trains of kilted followers, like Scottish chieftains. Phanariots and doctors of medicine, who in the month of April were clad in ragged coats, and who lived on scanty rations, threw off that patriotic chrysalis before summer was past, and emerged in all the splendour of brigand life, refulgent with brilliant but unused arms, fluttering about in rich Albanian habiliments, and followed by diminutive pipe-bearers and tall henchmen.FINLAY.
+Section 40. ioráva, Act. Voice, § 248.
+The Str. Aor., Perf., and 
+1. ἀντέστη αὐτῷ went against him. Plup. of iorával and its compounds are Intrans.
+NOTES TO PAGES 47, 48 
+= 
+87 
+1. és áropíav karaσrĥoai = to reduce to helplessness (Wk. Aor.).
+ἐς ἀπορίαν καταστῆναι to be reduced to helplessness (Str. Aor.). 6. evpnrai Delib. Subj.; evporo might have been used. See 41, 7 n. "Mehemet-Ali was a determined reformer, although his reforms, like those of all Eastern despots, were directed solely to two pointsaugmenting his revenue, and forming a disciplined standing army. The first he brought about by a most horrible system of oppression and monopoly, turning the cultivators into bondsmen and making himself the only merchant and landowner in the country; the second he effected by establishing an arbitrary conscription among the Arab villagers, and purchasing the services of European instructors." GORDON.
+1. τὰ τῆς χώρας . . . ἐς τὸ ἐπιτήδειον controlling the organisation of the country, he arranged matters to his own advantage.
+2. ὅδεv by which course.
+3.  ὅταν 
+whenever occasion should arise; Temporal Conjunctions compounded with ἄν (ὅταν, ὁπόταν, ἐπειδάν), followed by the Subj. have an Indefinite sense, expressed in English by ever. ever has one of two meanings :
+= 
+This 
+(i.) It refers to one occasion in the unknown future, e.g., whenever 
+at any time when) I die, I shall be cremated.
+(ii.) It refers to an unknown number of occasions, e.g., whenever (= at every time when) I am hungry, I eat.
+ὅταν is used in sense (i.); ὁπόταν in sense (ii.); ἐπειδάν in either 
+sense.
+See 11. 16, 20.
+1.  éteidη úñéσrn since he had undertaken the expedition.
+2.  ὁπότε 
+Xooler whenever they came to close quarters; after an historic tense, őre, óñóre, and éradý, followed by the Optat. are used in the same Indefinite sense, as orav, órórav, and éπeiðáv, with the Subj. See 1. 13 n. Compare the use of the Relative, 46, 29 n.
+Page, 48, 1. δέov, Acc. Abs. See 16, 22 n.
+Section 41. iorával Mid. and Pass., § 249. Súvapai I am able, éniorapai I know, are conjugated like iorapai, but see § 256.
+1.  ἕως ἂν reipŵvrai until they should try; ews åv so long as or until, péxpi av (or μéxpi ov äv) until, followed by the Subj., have an Indefinite sense, not expressed in English. They refer :
+:
+(i.) to one occasion in the unknown future, e.g., we will work, till we have finished.
+(ii.) to an unknown period of time, e.g., while there is life, there is hope.
+After an historic tense, the same Indefinite sense is expressed by ews, μéxpi (or μéxpi ov), followed by the Optat. Compare 47, 13 n, 26 n.
+888 
+NOTES TO PAGES 48-50 
+1.  Tois éπixεiρhμaoi, Instrum. Dat. they were not successful in (lit. by) their efforts.
+2.  οὐκ ἔχοντες 
+not having a point at which they should make a stand, i.e., a rallying point.
+Page 49, 4. ews ȧvaykaσbeiev. See 48, 11 n.
+1.
+At four o'clock in the afternoon, a soldier, bearing a lighted match, was seen to leave the monastery and run towards the entrance of a great subterraneous magazine, situated outside-he fell, pierced with balls, and five of his companions, following his example, one after the other, shared his fate. Unable to execute their first project, the Greeks resolved to inflame the powder they had within the monastery. They ceased their fire, and the Turks darting on, sword in hand, scaled the walls on every side; when suddenly the Hellenic flag was lowered, a white banner, inscribed with the words 'Liberty or Death,' waved in the air, a single gun gave the signal, and a tremendous explosion, shaking the island and felt far out at sea, buried in the ruins of St. Nicholas thousands of the conquerors and the conquered!"-Gordon.
+Section 42. δεικνύναι, §§ 250, 251.
+1.  A desultory siege of Patras continued throughout the war.
+the management of the loan was not in accordance 
+1.  τὰ περί . with their views.
+2.  πρίν . Karaλvσelav until they should overthrow the existing democracy. The Greeks had elected representatives, but great confusion had arisen owing to party quarrels. If the main verb is negatived, and où æρív not before means not until, æpív takes the same construction as μéxp and ews, 48, 11 n. When рiv means before, it takes the Infin.
+Page 50, 2. οὐ πρότερον πρίν 
+• • 
+not until; the Indic. is used referring to a Definite time, as is the case with all temporal conjunctions.
+1. διὰ τόν τε θάνατον 
+• 
+καὶ ὅτι (a) owing to his son's death, and (b) because the conspirators were unsuccessful. Cf. 14, 28 n.
+1.  καθίστατο τοῖς ἐν τοῖς ἀγροῖς befel the rural population.
+2.  διὰ τὸ ποιεῖσθαι. Cf. 19, 20 η.
+It was owing to this Civil War that no assistance had been sent to Cassos and Psara.
+Section 43. iévai Indic. Mood, § 267.
+1.  Neocastron, situated on the mainland opposite the south end of Sphakteria, is generally known as Navarino, from some merchants who came from Navarre and settled there in the fifteenth century.
+NOTES TO PAGES 51, 52 
+89 
+Page 51, 4. διὰ μáxns iévai to fight. Cf. διὰ þóßov eivai to be afraid, 36, 24.
+diá in such phrases expresses the circumstances, lit. to come into a state of battle.
+1. Tolavrηs i.e., against disciplined troops.
+2.  Sphakteria is famous as the scene of the Spartan surrender in B.C. 425.
+3.  karà tòv Xiμένa on the harbour side.
+4.  Mavrocordato, being a slow runner, would have been taken prisoner had not two soldiers helped him along, and got him on board a vessel from Hydra, named the Mars. For six hours he sat in the cabin, holding a pistol which might save him the ignominy of being sent in chains to Constantinople; he uttered no word except now and then a brief sentence expressive of the vanity of ambition, and a resolution, if he survived, to retire into private life. Meanwhile the Mars fought her way out of the harbour; the Turkish ships did not dare to approach too near, as the Greek captain could be seen standing with a lighted torch ready to blow up the ship, if any attempt was made to board her.-FINLAY.
+Section 44. lévai (all), § 267.
+1.  d' are is used with the Fut. Indic. to express on condition that. The Pres. Ind. of iéval (and its compounds) has a future meaning: the Past Imperfect and the other moods supply the missing forms of ἔρχομαι.
+OTOι av Boúλwvrau whithersoever they wished (lit. shall wish).
+• 
+Page 52, 5. ei èmíoiev if ever the enemy attacked; after an historic tense, ei with the Optat. expresses if ever. Cf. 47, 26 n. When the main verb is primary, the same meaning is expressed by v (= ei av), followed by the Subj. Cf. L. 8 and 47, 13 n.
+1. Tapà λóyov contrary to expectation.
+· 
+1. τήν τε πόλιν they burnt (a) the town, and (b) whatever they could not carry away. See 14, 28 n.
+2.  v πws if perchance, i.e., in hopes that; after an historic tense, this might be el mos with Optat. Cf. 53, 12.
+3.  When Colokotrones was imprisoned (see 50, 11), he exclaimed, "I have twice saved my country, and shall be called upon to save it a third time".-GORDON.
+4.  The Greeks were so demoralised that Colokotrones had great difficulty in keeping his men together. On one occasion his scouts rushed in crying, "Back, back, there are horsemen in the olive-yard". Presently, however, the horsemen were transformed into a flock of crows and flew away.-TRICOUPI.
+5.  During this expedition Ibrahim advanced nearly as far as Argos.
+90 
+NOTES TO PAGES 52-54 
+From a lofty point in the road he caught a view of Hydra, and, stretching out his hand, exclaimed, “Ah, little England, how long wilt thou escape me?"-GORDON.
+Section 45. didóvaı, Act. Voice, § 262.
+1.  When the Turks retired from Messalonghi (Section 36), they buried their guns, and erected tombstones over them: the Greeks were deceived by this stratagem, and proudly pointed to the inscriptions which recorded the fate of their enemies. When Kiutayhé (or Reschid Pasha, as he was generally called) began the second siege, he dug up the guns and used them against the Greeks.
+2.  εἰ μή except.
+Page 53, 2. ei.
+• 
+éyévero if this had not been done, they would have been compelled. Unfulfilled Past Condition.
+1. ÓTÓTE. Cf. 47, 26 n.
+2.  εἴ πως. Cf. 52, 11 n.
+• 
+ἄνευ Toλioρkías, lit. without expense and a siege, i.e., without a costly siege.
+1.  λίθους τε .
+καὶ εἴ τι 
+Cf. 52, 9 n.
+1.  dúvaσbai ǎv would be able; this could have been expressed őri δύναιτο ἄν. Cf. 40, 18 n.
+• 
+1.  οὐδεμίαν avrov they had no hope that (is) they would prevail, unless they were to get possession of it.
+2.  Tò èpyov, i.e., the making of the mound; poσéxovor is Dat. Plur. of Partic.
+Section 46. didóva, Mid. and Pass., § 263.
+1.  καλῶς ἔπραξαν.
+Cf. 31, 21 n.
+Page 54, 2. čws äv. Cf. 48, 11 n.
+1.  καθ' ἡμέραν 
+προϊούσαν as each day came on.
+1.  ἀσθενέστεροι ἢ ὥστε too weak to. Cf. 31, 5 n.
+2.  "At Messalonghi, when they issued forth amid the drizzle of the night, feeling their desolation and their doom, they said to one another, 'The Almighty Himself weeps for us to-night!' But they went on, sword in hand, to fall for their country, greeting her with the gladsome cry, 'Arise, thou dearest mother!""GENNADIUS.
+3.  κραυγῇ . by some cry of confusion (lit. of those confused). "Almost at the moment when the garrison rushed on the Turks, that portion of the Messalonghiots which was then on the bridges raised a cry of 'Back, back'. Great part of the Messalonghiots stopt, fell back, and returned into the town with the military escort, which ought to have formed the rear-guard of the sortie. The origin of this ill-timed cry, which weakened the force of the sortie and added to the victims in the place, has excited much unnecessary speculation. It 
+NOTES TO PAGES 54-57 
+91 
+evidently arose among those who were in danger of being forced into the ditch. Their cry was repeated so loudly that it created a panic." FINLAY.
+Page 55, 4. ὅσοις ἐντύχοιεν. Cf. 46, 29 n.
+1.  εἴ πως. Cf. 53, 12.
+2.  âv éyévero. Cf. 53, 2 n. The deserter was a Bulgarian mer
+cenary.
+Section 47. Str. Aor., ἔβην, ἔγνων, ἑάλων, ἔδυν, §§ 271, 272.
+1.  où πpoσĥkov, Acc. Abs. See 16, 22 n. 25. Bore on condition that.
+2.  τοὺς δὲ μὴ δεχομένους.
+(saying) that they would compel those 
+who rejected the terms to observe them. 29. ǎopevo gladly. Cf. 42, 28 n. Page 56, 11. ổơa .
+Section 48.
+idolev. See 46, 29 n.
+1.  The English admiral, Sir Edward Codrington, was in command of the whole fleet, as being the senior admiral. The instructions which he gave to his colleagues in the event of a general engagement concluded with Nelson's words, that no captain could do very wrong who placed his ship alongside that of an enemy.—FYFFE.
+2.  οὐ πολὺς χρόνος. Cf. 37, 21 n.
+Page 57, 1. v it was possible. Cf. 1. 8.
+1. rà vaváyia, some of these wrecks are still to be seen on shore and beneath the water.
+2.  ἐμοί 
+• 
+peλnoe, these are the concluding words of Xenophon's Hellenica. uoi is Dat. of Agent, by me.

--- a/drafts/chambers_notes_ocr.md
+++ b/drafts/chambers_notes_ocr.md
@@ -1,8 +1,10 @@
 # NOTES.
 
-*References are made to the text by Pages and Lines, e.g., 3, 10 means page 3, line 10.*
+*References are made to the text by Pages and Lines, e.g., [REF] means [REF].*
 
-## INTRODUCTORY NOTE TO SECTIONS 1 AND 2 
+## Part 1
+
+### INTRODUCTORY NOTE TO SECTIONS 1 AND 2 
 During the first few lessons, while the Greek Alphabet [REF] and the portions of Grammar given below are being learnt, it is intended that these two sections should be used for practice in reading, and should be translated by instalments to the class.
 
 Nouns should be declined *viva voce*, and also on paper, with or without an adjective and the article, *e.g.*, ἡ μικρά γῆ, ἡ χαλεπὴ ὁδός, στενός Ἰσθμός. Similarly the Pres. Ind. of verbs should be conjugated, *e.g.*, ἔχειν.
@@ -11,7 +13,7 @@ Attention should be drawn to cognate words in English and Latin (*e.g.*, κόλ�
 
 As occasion arises, emphasis should be laid on (A) the connection between sentences, and (B) the uses of the Article. The rules are collected here for convenience, but, of course, only one or two points will be dealt with in any one lesson.
 
-### A. 
+###### A. 
 (i.) Every sentence is connected with its predecessor by a conjunction or connecting particle; of these the commonest are καί *and* [REF]; δέ *but* , unemphatic [REF]; γάρ *for* [REF]; ἀλλά *but*, emphatic [REF]; οὖν *therefore* [REF]; τε *and* [REF]; μέντοι *however* [REF]; ἔπειτα *then* [REF]. Notice that δέ, γάρ, οὖν, τε, μέντοι, do not come first word in the sentence.
 
 (ii.) There is one exception to the above rule. When the demonstrative pronoun οὗτος *this*, or its derivatives οὕτω *thus*, τοιοῦτος *οf such a kind*, sum up what has already been stated, no conjunction is required [REF]; similarly, when the demonstrative pronoun ὅδε *this*, or its derivatives, ὧδε *thus*, τοιόσδε *of such a character*, look forward to what is coming, no conjunction is required with the following sentence [REF].
@@ -22,7 +24,7 @@ As occasion arises, emphasis should be laid on (A) the connection between senten
  
 πρῶτον μέν *firstly*, is habitually answered by ἔπειτα *secondly*, not by ἔπειτα δέ, as we should expect [REF].
 
-### B. The uses of the Article. 
+###### B. The uses of the Article. 
 (See also headings to Ex. 1-6.)
 
 (i.) It is habitually used with the names of countries, islands and towns, ἡ Ἑλλάς *Greece* [REF]; ἡ Εὔβοια *Euboea* [REF]; αἱ Ἀθῆναι *Athens*; and with Proper Nouns, if the person is well known or has previously been mentioned, ὁ Πέλοψ *Pelops* [REF].
@@ -45,7 +47,7 @@ oi δέ necessarily comes first in its clause, A. (iv.): oi μέν generally c
 
 (ix.) The Article with an adjective, a prepositional phrase, an adverb, or a genitive case, forms a noun-equivalent, οἱ παλαιοί *the ancients* [REF]; ἡ παραθαλάσσιος *the coast* [REF]; τὸ δίκαιον *justice* [REF]; οἱ κάτω *those on the coast* [REF]; οἱ ἐν τῇ μεσογείᾳ *those in the interior* [REF]; οἱ κατ' ἤπειρον *those along the mainland* [REF]; οἱ ἐν τῇ ξυνωμοσίᾳ *the members of the conspiracy* [REF]; οἱ μετ' αὐτοῦ *his companions* [REF]; τὰ ἐν τῷ στρατοπέδῳ *the state of the camp* [REF]; τὰ περὶ τῆς ξυνωμοσίας *the facts about the conspiracy* [REF]; τὰ τῶν Τούρκων *the property of the Turks* [REF].
 
-## Section 1. 
+### Section 1. 
 
 ἡ μάχη, ὥρα, [REF]; ὁ δοῦλος, [REF]; στενός, μικρός (Masc. and Fem.), [REF].
 
@@ -70,7 +72,7 @@ Pres. Ind. of εἶναι, εἰμί ; of λύειν, λύω, [REF].
 16. For this use of an adverb for an adjective, compare 1 Tim. v. 23, *thine often infirmities*.
 17. καί ... καί. Introd. Note A. (iii.).
 18. The modern name of the Achelous is Aspropotamo, meaning White-river.
-19. τὰς πηγάς *its springs*, *cf*. [REF] *n*.
+19. τὰς πηγάς *its springs*, *cf*. [REFn].
 20. τὸν Ἰόνιον. Introd. Note B. (iii.).
 21. διά with Gen. means *through* (as here), or *by means of*; with Acc. it means *on account of*.
 22. ἡ ἐπιμειξία *communication*. Introd. Note B. (v.).
@@ -78,12 +80,12 @@ Pres. Ind. of εἶναι, εἰμί ; of λύειν, λύω, [REF].
 24. μεγίστη *the largest*; the Article is omitted with a *predicated* adjective in Greek. Introd. Note B. (vi.).
 25. τε ... καί ... καί. Introd. Note A. (iii.).
 
-## Section 2. 
+### Section 2. 
 
 τὸ δῶρον, [REF] ; Neut. of στενός, μικρός, [REF]; δόξα, [REF]; ὅδε, [REF].
 
 1. κατὰ τήν ἀρχήν *at the beginning*.
-2. ὅδε this is declined like the Article with δε added; when it is used with nouns, the Article must also be used immediately before the noun; ὁ πόλεμος ὅδε or ὅδε ὁ πόλεμος *this war*. For exception, see [REF] *n*.
+2. ὅδε this is declined like the Article with δε added; when it is used with nouns, the Article must also be used immediately before the noun; ὁ πόλεμος ὅδε or ὅδε ὁ πόλεμος *this war*. For exception, see [REFn].
 3. οἱ μέν ... οἱ δέ. Introd. Note B. (viii.).
 4. κατὰ κώμας ἀτειχίστους *in unfortified villages*. Compound adjectives (ἀ-τείχιστος *un-walled*) have no separate form for the Fem. *Cf*. παραθαλάσσιος, πολυάνθρωπος [REF].
 5. οἱ δὲ κάτω *but those on the coast*, the Article with an adverb forming the equivalent of a noun. Introd. Note B. (ix.).
@@ -94,14 +96,14 @@ Pres. Ind. of εἶναι, εἰμί ; of λύειν, λύω, [REF].
 10. οἱ ἐν τῇ μεσογείᾳ. Introd. Note B. (iv.).
 11. τούς τε ἄλλους... *to pay tithes of their produce and other taxes*; the English order is the reverse of the Greek order.
 12. ὥστε with Ind. introduces a Consecutive Clause, *so that*.
-13. δι' ἁρπαγῆς, see [REF] *n*.
+13. δι' ἁρπαγῆς, see [REFn].
 14. ὥσπερ κλέπται *as Clephts*. The Clephts (lit. robbers) were those Greeks, who in defiance of the Turkish authorities carried on a predatory warfare from the hills. Many of them were popular heroes, and their existence helped to keep alive the patriotism of the Greeks.
 15. τὰ τῶν Τούρκων *the property of the Turks*. Introd. Note B. (ix.).
 16. τῶν πρὶν φίλων, see [REF].
 17. ὁ κίνδυνος. Introd. Note B. (v.).
 18. οὕτω δή *in this way*. δή only emphasises οὕτω, which sums up what precedes. For omission of conjunction, see Introd. Note A. (ii.).
 
-## Section 3.
+### Section 3.
 
 δεσπότης, [REF].
 
@@ -112,7 +114,7 @@ Pres. Ind. of εἶναι, εἰμί ; of λύειν, λύω, [REF].
 5. διὰ τάδε *for the following reasons*. For the omission of a conjunction in the following sentence, see Introd. Note A. (ii.).
 6. πρῶτον μέν is answered by ἔπειτα in [REF]. Introd. Note A. (iv.).
 7. ὅτι *that* introduces a noun-clause, after verbs of thinking, knowing, feeling, seeing, saying, etc.
-8. αὐτοί *(they) themselves*, cf. [REF] *n*.
+8. αὐτοί *(they) themselves*, cf. [REFn].
 9. έχουσι τούς δεσπότας ἀξυνέτους lit. *they have their masters ignorant*, i.e., *the masters they have are ignorant*. ἀξυνέτους is a predicated adjective, and so has no Article. This is the common idiom with ἔχειν
 10. ἄδικα πάσχουσιν ὑπό... lit. *suffer unjust things by*, ie., *suffer unjustly at the hands of*. ὑπό with Gen. is the ordinary way of expressing the Agent after Passive Verbs (Lat. *ab* with Abl.); it is also used, as here, with Intransitive Verbs which have a Passive meaning, *are unjustly treated by*.
 11. οἷοι τ' εἰσί lit. *are such as to*, i.e., *are able to*; so οἷόν τ' ἐστίν *it is possible*. τε in early Greek was added to Relative words, e.g., ὥστε, and in such cases means nothing at all.
@@ -120,221 +122,240 @@ Pres. Ind. of εἶναι, εἰμί ; of λύειν, λύω, [REF].
 13. οὐδέν... δικαίον *the judges do not care at all either for the laws or for justice*. In Greek two negatives only strengthen one another, provided that the second one is compound. τὸ δίκαιον *justice*. Introd. Note B. (ix.).
 14. μετὰ δώρων... *they decide cases with gifts*, i.e., *under the influence of bribes*.
 15. εἰσί is understood with ἔμπειροι δέ from the previous clause. In general if a word or group of words is required with two clauses, it is inserted in the first clause and understood in the second.
-16. οὕτω. See [REF] *n*.
+16. οὕτω. See [REFn].
 17. ὧν *of which*; the Rel. Pron. ὅς, ἥ, ὅ is declined in its other cases like the Article with a rough breathing instead of τ, [REF].
 18. τὰ μὲν... ἐκ δὲ τῶν. Introd. Note Β. (viii.). 
 19. φέρει. Neut. Plurals in Greek take a Singular Verb. This arose from an original use of the Neut. Plur. as a singular collective noun.
-20. ἀθάνατον. See [REF] *n*.
+20. ἀθάνατον. See [REFn].
 
-## Section 4. 
+### Section 4. 
 
-Past Imperfect of εἶναι, ή; of λύειν, ἔλυον, p. 147. Syllabic Augment, p. 147; Strong Aorist, p. 148.
-1. κατά αι, cf. 4, 12.
-• 
-1. τοῖς παρά those along the shore of the Black Sea.-Introd. Note B. (iv.). The name Euxine (hospitable) was given it to avoid the original ill-omened name of "Aĝevos (inhospitable).
-2. xаλeñ@s peрov, like Lat. aegre ferebant, were indignant at. On augment, see p. 147.
-3. Thy Tay Touρкkov aрxýv.-Introd. Note B. (iv.).
-ȧñoσróλous, the envoys of the conspirators were called Apostles, i.e. messengers.
-1.  oσovs Teidov all whom they persuaded; the suppressed antecedent of this clause is the object of ξυνάγουσιν.
-2.  oi kar' meipov those on the mainland.—Introd. Note B. (ix.). 13. Kai . . . Kaí.-Introd. Note A. (iii.).
-3.  toùs év tŷ §vvwμoơią.—Introd. Note B. (ix.).
-The Philiké Hetairia, or Association of Friends, was the successor of the Philomuse Society, which had as its object the encouragement of Greek literature; in 1815, it became a political society for the purpose of raising an insurrection against the Turks. The members, on being initiated, swore on their knees at dead of night to be faithful to their afflicted country, to labour for her regeneration, not to disclose either the secrets of the society or the name of the person who initiated them, and to put to death their nearest and dearest relations, should they be guilty of treachery.-GORDON.
-1.  οἱ μέν in contrast with τοῖς δὲ προστάταις, 1. 20. ¿Bouλevov ori gave their opinion that. Cf. 5, 10.
-2.  xp is a noun, meaning necessity. It is used (with eorí understood but never expressed) to mean it is necessary. The Past Imperf. is χρῆν (χρὴ ἦν), and the Inf. χρῆναι (χρὴ εἶναι).
-χρή is understood with κατακαίειν, κτείνειν and ἀναλαμβάνειν. See 5, 23 n.
-L 
-NOTES TO PAGES 6, 7 
-1.  τοῖς προστάταις ἦν γνώμη the leaders determined. 21. πρῶτον μέν 
-Teira.-Introd. Note A. (iv.). πόλεμον belongs to both clauses.
-65 
-ἐξάγειν ἐς τὸν 
-The provinces of Moldavia and Wallachia form the present kingdom of Roumania. The Hetairists wished the first outbreak to take place in this district because it would be easy for Russia to send troops to their assistance.
-1.  τε 
-και 
-• 
-· 
-Kaí.-Introd. Note A. (iii.).
-1.  ópíčel. See 6, 1 n.
-2.  Constantinople drew its principal supply of food from the rich alluvial plain of these provinces.
-3.  By the treaty of Bukharest, between Russia and Turkey, the Sultan had undertaken to appoint Christian governors (called Hodospars) over these provinces, and not to keep more than a small number of Turkish troops in them.
-diéTEμTE, for Augment of verbs compounded with prepositions, see p. 148.
-Page 7, 4. 8' ovv 80, is used after a parenthesis or a digression, resuming the main narrative.
-1. Após in relation to, i.e., for. 10. ἔπρασσον πρός negotiated with. Theodore Vladimiresko (so-called because he had received the Russian Order of St. Vladimir) had been a colonel in the Russian army. As he was a Wallachian landowner, he had great influence among the natives.
-2.  Georgaki (the name is the diminutive of George) was a Greek from Mount Olympus, and at this time in command of the troops at Bukharest. Caravia was captain of the garrison at Galatz.
-3.  čμalov, for Strong Aorist, see p. 149.
-тà пερì τns Evvшμoorías.-Introd. Note B. (ix.).
-Section 5. râs, p. 145; Temporal Augment, p. 147.
-1.  0, for Strong Aorist, see p. 149.
-παντὰ τὰ ἐν τῇ Μολδοβλαχίᾳ all the arrangements in Roumania.
-1.  τὸν Ὑψιλάντην στρατηγὸν προστάξαντες appointing Hypsilantes general. Participles in -as are declined like râs, and are given in the Vocabulary as adjectives.
-Prince Alexander Hypsilantes had served in the Russian Imperial Guard, and had lost an arm at the battle of Culm in 1813; after the peace of 1815 he grew weary of inaction and entered warmly into the plans of the Hetairists.
-...
-1.  ős ・ ・ åñéðave who had been put to death by the Turks on a charge of treachery. The Aorist in a subordinate clause often refers to a time which is past from the point of view of the main clause; in these cases we use the Pluperfect in English. vñó, see 5, 16 n.
-2.  & ovv. See 7, 4 n.
-5 
-66 
-NOTES TO PAGES 7, 8 
-1.  és diakoσiovs to the number of 200; a common use of ès with numerals.
-2.  óμnpovs aßov seized as hostages.
-3.  deopoîs lit. with chains, Instrum. Dat. 4, 24 n. 27. πλην oσoi àrévyov except those who had escaped. Tλn is also used as a Preposition, 6, 29.
-4.  ér' èλevbepía to secure the freedom of the people.
-ἥκει . . . μέλλει, had come intended; notice that in nounclauses introduced by or, the original tenses are retained; for instance, in the proclamation Hypsilantes said, I am come... Russia intends, therefore the Present tenses are retained, though we translate them by Past tenses. Cf. 11. 14, 16, and passim.
-At the end of the proclamation came these words: "If some desperate Turks venture to make an incursion into your territory, fear nothing; for a Great Power is ready to punish their insolence". The "Great Power" was, of course, Russia.
-Page 8, 1. Instead of taking military precautions Hypsilantes commenced operations by seizing a wealthy banker whom he accused of being hostile to the Revolution and concealing funds belonging to the Hetairia. The first accusation was not a crime and the second was false; but the banker was glad to pay the prince several thousand pounds to escape out of his hands. This act of extortion alarmed the wealthy citizens, who, afraid of being robbed by the Greeks, availed themselves of every opportunity of escaping into Russia and Austria 
---FINLAY.
-1. ¿s eidov when they saw. For Augment, see p. 149.
-2. évóμicóv тe and they thought; re is here used as a conjunction, joining two sentences.-Introd. Note A. (i.).
-3. où pédλei was not likely; for tense, see 7, 28 n.
-4.  ékeî.-Introd. Note B. (iv.).
-5.  тà Tâν éμπóрpwv.-Introd. Note B. (ix.).
-6.  Kaì AVTOì Tò avrò eπpaσσov themselves too did the same. Cf. 5, 10 n. aurós immediately preceded by the article means same.
-7.  ékáλvov tried to prevent.
-Section 6. Tís, p. 144; rɩs, p. 146.
-1.  μerá with Acc. after; with Gen. with, 1. 22.
-Tроúßaive, for Augment, see p. 148.
-• 
-1.  εἴ τις καὶ ἄλλος . lit. if any one else also of those in the conspiracy (was loyal), i.e., was as loyal as any one.
-2.  VσTepov subsequently, as related in Sect. 12.
-3.  Tŵv EK Tηs Tepioixidos.-Introd. Note B. (ix.).
-4.  xápiri by his influence.-Instrum. Dat. 4, 24 n.
-5.  ἐν ἐλπίδι καταλύειν καὶ . . . ἀναλαβεῖν he is in hopes of over
-· 
-NOTES TO PAGES 8-10 
-67 
-throwing . . . and recovering. Notice that the Aor. Infin. does not refer to past time. See p. 150.
-1.  τῷ αὐτῷ, 1. 13 n.
-• 
-Page 9, 1. ἐν παντὶ δὴ ἀταξίας lit. in everything of disorder, i.e., in a state of utter disorder and suspicion. 8n only emphasises πâs, cf. 5, 2.
-1. Tapeixe, for Augment, see p. 149.
-2. Výkovov takes either the Gen. (as here) or the Dat..
-3.  This Sacred Battalion consisted of about 500 Greeks; their uniform was black with a cross formed of bones in front and Constantine's inscription, In hoc signo vinces.—ALISON.
-Section 7. Pres. Ind. of Toleîv, πoιâ, p. 148.
-1.  ouros eixe, with adverbs exew means to be; when matters in the camp were in this condition.
-2.  ὑπ ̓ ὀργῆς angrily.
-κρύφα αὐτοῦ without his knowledge.
-1.  Besides disavowing the Insurrection, the Czar (Alexander I.) commanded Hypsilantes "to proceed no further, but on the contrary if possible to disband the unhappy men, whom you have misled". Hypsilantes pretended that the Russian proclamation was only a blind to deceive the Turks, and that the Czar was really sending troops to support him.
-2.  orparia with an army; the Instrumental Dative is very common in military phrases, expressing the accompanying force.
-3.  ὅσα . Καραβιού, see 6, 10 η.
-4.  ônó. See 5, 16 n. τὴν τιμωρίαν ávaλaußávew to take vengeance on those who had committed the crime. The Participle with the Article is equivalent to a noun, just as an adjective with the Article is ; ó ádikýσas or ó ädikos 
-the wrong-doer.
-= 
-1.  oi μer' avrov lit. those with him, i.e., his troops.-Introd. Note B. (ix.).
-66 
-1.  TOû BOUKоUpeσríov from Bukharest. The Gen. in Greek expresses separation," from, like the Lat. Abl. of Separation. Cf. 3, 7 n. 30. Xov, for Augment, see p. 149.
-• 
-Page 10, 6. Xaßeiv to receive the governorship as the reward of his treachery. Cf. 8, 28 n.
-1.  avropolia xwpeiv to go by desertion, i.e., to desert; avropoλíą is Dat. of Manner, like Lat. Abl. of Manner.
-BOTE on condition of; &ore often introduces the terms of an agreement.
-Section 8. Past Imperf. of roleîv, éπoiovv, p. 148.
-1.  eival, Or. Obl., he said he was disloyal.
-68 
-1.  vñó, 5, 16 n.
-NOTES TO PAGES 10-12 
-Caravia and another officer butchered him in a 
-barbarous way with their sabres.
-1.  προσεχώρουν 
-· 
-joined the Turks as deserters.
-Page 11, 4. és ỏKTAKOσíovs ivás to the number of some eight hundred. Cf. 7, 23 n.
-1. édókeι To Tewрyákŋ it seemed good to Georgaki, i.e., G. determined. One of the reasons for postponing the engagement was the fact that the day was a Tuesday which is regarded as an unlucky day in the East.
-2. Kúkλw by a circuitous way.
-3. Bore with Inf. gives the result, whether it is the actual or only the probable result; with the Ind. it gives the actual result only, 4, 5; so as to cut them off and prevent them escaping.
-4.  οὕτω in this way they were likely to kill them all.
-• • 
-1.  Eppel, for Augment, see p. 147.
-2.  στάδια, the plur. of στάδιον is either στάδια οι στάδιοι, 9, 29.
-Section 9.
-1.  Caravia was always reckless, and on this occasion happened to be intoxicated.-GORDON.
-2.  70eλe... he wished the glory of the victory to belong to his men. eival with Dat. is used to express 66 belong to" or 
-"have" like Lat. est mihi liber, I have a book.
-1.  åμa rŷ éσtéρa lit. with the evening, i.e., at sunset. dua is often used as a prep. with words denoting "time". 23. inπos horse is sometimes used as a collective noun, meaning Cavalry, just as we speak of So-and-so's Horse meaning "mounted regiment". Tоs in this sense is fem.
-"the 
-1.  eidov is plur. because the "battalion" is regarded as soldiers"; so too kaì avroí in 1. 26. Verbs of sense-perception (e.g., seeing, knowing, hearing, etc.) take the Acc. and Partic. in Greek, as they may do in English, saw him advancing.
-2.  pyov action; used in Greek as we use action to denote battle. Ovμą kaì þóμŋ with spirit and confidence; Dat. of Manner. Cf. 10, 10 n.
-3.  pedλov they were on the point of leaving the village. Cf. 1. 9. Page 12, 1. oi órλîrai, viz., the troops mentioned in 11, 8. 4. Spouw, Dat. of Manner. Cf. 10, 10 n.
-4. ἔτρεπον routed them ; τοὺς ἐναντίους is understood from τοῖς ἐναντίοις.
-5. is eiπeiv 80 to speak; this phrase is used to apologise for an exaggeration; Távτas às eineîv = practically all, not literally all. The Infin. eireiv is used absolutely, i.e., without any syntactical construction with the sentence.
-NOTES TO PAGES 12, 13 
-Section 10. ovTOS, p. 147.
-69 
-1.  ταῦτα this ; οὗτος refers to what precedes, ὅδε refers to what is coming, 5, 9.
-2.  ἔτυχον παραστάντες happened to be standing near ; τυγχάνω takes the Participle where we use the Infinitive.
-3.  ὅσοι . λόχου, see 6, 10 κ.
-4.  oi δέ.-Introd. Note B. (viii.).
-5.  τῷ δ' Ὑψιλάντῃ ἀθυμία ἐνέπεσε Hypsilantes became disheartened. ταύτης τῆς μάχης, οὗτος requires the article to be used before the noun, as ode does. Cf. 4, 12 n.
-6.  T vσrepaia, sc. nμépa, on the next day. When an event is dated by the particular day, night, month or year of its occurrence, the Dat. is used without a prep., otherwise the prep. év is used.
-7.  The proclamation began, "Soldiers! I can hardly bring myself to sully that honourable and sacred name by applying it to persons such as you.
-Henceforth every bond is severed between us ; but I shall ever feel profoundly the shame of having been your chief."ALISON.
-1.  ἐσπίπτει is thrown into ; the Passive of compounds of βάλλειν throw is formed by the corresponding compounds of wirew fall, e.g., ἐκβάλλω I expel, ἐκπίπτω I am expelled; cf. ἀποκτείνω I kill, ἀποθνῄσκω I am killed.
-ai apxaí, Abstract for Concrete, the Austrian authorities.
-1.  voo lit. by disease, Instrum. Dat. 4, 24 n, he fell ill and died. Hypsilantes was kept as a prisoner until 1827, when he was released, but he died in the following year from the effects of imprisonment in unhealthy fortresses.
-Page 13, 1. ἐν goes with ἀπορίᾳ as well as with κινδύνῳ.
-1. ἐπ ̓ οἴκου homewards, ἐπ ̓ οἶκον home ; ἐπί with Acc. states where one goes; with Gen. it states the direction only.
-2. ¿dókovy seemed, édóke it seemed good; the two uses are the same as those of Lat. videri.
-3. evpeiv. See 8, 28 n.
-Section 11. φύλαξ, ἀγών, οἰκήτωρ, p. 144.
-1. τοὺς στρατιώτας is the object of ἀπολείπειν, which can be used transitively, as here, or intransitively 1. 19 (ảπodeíneiv ék tov ảyŵvos to desist from the struggle).
-2.  λaßeiv, Or. Obl., they considered that they had taken up arms. Cf. 10, 16.
-3.  Bσteρ kλétтai nodeμeîv to carry on a guerilla warfare. Cf. 4, 30. 15. ὅσα . . Τούρκων, see 6, 10 η.
-4.  Táde.-Introd. Note A. (ii.). 21. τῇ τρίτῃ ἡμέρᾳ. Cf. 12, 21 n.
-τῶν ἄλλων, masc.
-70 
-NOTES TO PAGES 13, 14 
-1.  Oárepa is a contracted form of rà êrepa, lit. the other parts, i.e., the other side.
-Page 14, 1. eveov, for uncontracted form, see p. 149.
-1. vπηрxev avrois lit. existed for them, i.e., they found a refuge. Cf. 11, 20 n.
-Section 12.
-1. éπì dúo μnvas for two months; Duration of Time is expressed by the Acc. alone or with éπí.
-2.  Téλos, as adverb, at last.
-3.  Monasteries were often used during the war as fortresses, or places to store ammunition; in some cases the books they contained were destroyed to provide paper for cartridges.
-4.  VUKTós by night. The Acc., Gen. and Dat. are all used to denote time. μέλλει μάχεσθαι τήνδε τὴν νύκτα, νυκτός, τῇδε τῇ νυκτί, he intends to fight throughout this night, by night, on this night. The Acc. implies that the fighting and the night last the same length of time; the Gen. implies that the night lasts longer than the fighting; the Dat. disregards duration altogether, and merely states that the night and the fighting occurred together. Cf. 11, 6, 12, 21.
-5.  Kýρvka a man with a flag of truce.
-6.  ädelav Toleiv to give a safe conduct to Georgaki and all the others who were there. The clause oσo παρῆσαν is equivalent to πᾶσι τοῖς ἔνδον.
-• • 
-1.  Georgaki addressed his followers thus: "Brothers, in our present circumstances, a glorious death is all we ought to wish for, and I trust there is no one here base enough to regret his life. Let us imitate those true Greeks our comrades, whose dead bodies are stretched on the fields of Dragashan and Skuleni and whose blood yet cries for vengeance. If we die like them, perhaps on some future day our countrymen will gather up our bones, and transport them to the classic land of our forefathers."-GORDON.
-2.  Túpyor the belfry.
-3.  éμmphoas having set it (the gunpowder) alight.
-4.  ap' où (8c. xpóvov) from the time when.
-5.  Two reasons are given for the failure (i.) διὰ rýv te áέvverríav, and (ii.) ὅτι οὐκ ἐνόμιζον . owing to the folly of Hypsilantes and because the inhabitants did not think, etc. It is very common in Greek to express two parallel ideas by two different syntactical constructions. Cf. 1. 16, where a noun and a rel. clause are parallel; and 11, 1, xadeπŵs kaì èv ver where an adverb and a prepositional phrase are parallel.
-NOTES TO PAGES 15, 16 
-71 
-PART II.
-SS REFER TO SONNENSCHEIN'S GREEK GRAMMAR.
-Section 13. Pass. and Mid. Pres. of λúew, Ind. λvopai, Inf. λveolai, Part. Avóuevos, § 183. Pres. Part. Act. of εἶναι, ὤν ; of λύειν, λύων ; Str. Aor. ἐλθών ; all like ἑκών, § 99, of ποιεῖν, ποιῶν, § 198.
-· • 
-• • 
-Page 15, 1. πρὶν 3. παρασκευάζονται The Middle Voice has a reflexive meaning, implying that the agent is working for or upon himself; in most cases English does not admit of this shade of meaning, and the Mid. is translated as if it was an active or neuter verb: e.g., Boúλovraι they wish (1. 7), páxeobal to fight (1.8). In some cases, however, the reflexive force is retained, παρασκευάζονται they make themselves ready; ἀμύνονται they ward of from themselves, i.e., they defend themselves.
-Ocîv before affairs in Roumania came. get ready to meet the crisis.
-1. Y. σтparηyouvros under command of Hypsilantes. The Gen. case is used Absolutely in Greek, like Lat. Abl. Abs.
-2. rà ŏvra the things that are, i.e., the truth.
-3. The Greeks were encouraged by several monks and hermits who issued from their cells and wrought on the superstition of the peasantry by visions and prophecies.
-4.  γάρ often introduces a narrative, alluded to in the previous clause. In English no corresponding conjunction is used.
-čtvɣov áπoßáνtes happened to disembark. Cf. 12, 11 n.
-1.  The Turkish armies were largely recruited from the Albanians, who enjoyed a high reputation for bravery.
-2.  és xapádpav évý pevov set an ambuscade in a ravine; cf. Lat. abdere se in silvam.
-ἐς εἴκοσι. Cf. 7, 23.
-1.  τούτων γενομένων. See l. 5.
-Page 16, 6. μédλovorav coming.
-Section 14. Pass. and Mid. Pres. of roleîv, Ind. Tolovμai, Inf. ποιεῖσθαι, Part. ποιούμενος, § 199; ὄνομα, § 32 ; γένος, § 33.
+Past Imperfect of εἶναι, ή; of λύειν, ἔλυον, [REF]. Syllabic Augment, [REF]; Strong Aorist, [REF].
+
+1. κατά *at*, cf. [REF].
+2. τοῖς παρά ... *those along the shore of the Black Sea*. Introd. Note B. (iv.). The name Euxine (*hospitable*) was given it to avoid the original ill-omened name of Ἄξενος (*inhospitable*).
+3. χαλεπῶς ἔφερον, like Lat. *aegre ferebant*, *were indignant at*. On augment, see [REF].
+4. τὴν τῶν Τούρκων ἀρχήν. Introd. Note B. (iv.).
+5. ἀποστόλους, the envoys of the conspirators were called Apostles, i.e. messengers.
+6. ὅσους ἔπειθον *all whom they persuaded*; the suppressed antecedent of this clause is the object of ξυνάγουσιν.
+7. οἱ κατ' ἤρειρον *those on the mainland*. Introd. Note B. (ix.). 
+8. καί... καί. Introd. Note A. (iii.).
+9. τούς ἐν τῇ ξυνωμοσίᾳ. Introd. Note B. (ix.).
+The Philiké Hetairia, or Association of Friends, was the successor of the Philomuse Society, which had as its object the encouragement of Greek literature; in 1815, it became a political society for the purpose of raising an insurrection against the Turks. The members, on being initiated, swore on their knees at dead of night to be faithful to their afflicted country, to labour for her regeneration, not to disclose either the secrets of the society or the name of the person who initiated them, and to put to death their nearest and dearest relations, should they be guilty of treachery. -GORDON.
+10. οἱ μέν in contrast with τοῖς δὲ προστάταις, [REF].
+11. ἐτούλευον ὅτι *gave their opinion that*. Cf. [REF].
+12. χρή is a noun, meaning *necessity*. It is used (with ἐστί understood but never expressed) to mean *it is necessary*. The Past Imperf. is χρῆν (χρὴ ἦν), and the Inf. χρῆναι (χρὴ εἶναι).
+13. χρή is understood with κατακαίειν, κτείνειν and ἀναλαμβάνειν. See [REFn].
+14. τοῖς προστάταις ἦν γνώμη *the leaders determined*. 
+15. πρῶτον μέν... ἔπειτα. Introd. Note A. (iv.). ἐξάγειν ἐς τὸν πόλεμον belongs to both clauses.
+16. The provinces of Moldavia and Wallachia form the present kingdom of Roumania. The Hetairists wished the first outbreak to take place in this district because it would be easy for Russia to send troops to their assistance.
+17. τε... καί... καί. Introd. Note A. (iii.).
+18. ὁρίζει. See [REFn].
+19. Constantinople drew its principal supply of food from the rich alluvial plain of these provinces.
+20. By the treaty of Bukharest, between Russia and Turkey, the Sultan had undertaken to appoint Christian governors (called Hodospars) over these provinces, and not to keep more than a small number of Turkish troops in them.
+21. διέπεμπε, for Augment of verbs compounded with prepositions, see [REF].
+22. δ' οὖν *so*, is used after a parenthesis or a digression, resuming the main narrative.
+23. πρός *in relation to*, i.e., *for*. 
+24. ἔπρασσον πρός... *negotiated with*. Theodore Vladimiresko (so-called because he had received the Russian Order of St. Vladimir) had been a colonel in the Russian army. As he was a Wallachian landowner, he had great influence among the natives.
+25. Georgaki (the name is the diminutive of George) was a Greek from Mount Olympus, and at this time in command of the troops at Bukharest. Caravia was captain of the garrison at Galatz.
+26. ἔμαθον, for Strong Aorist, see [REF].
+27. τὰ περὶ τῆς ξυνωμοσίας. Introd. Note B. (ix.).
+
+
+### Section 5.
+
+πᾶς, [REF]; *Temporal Augment*, [REF].
+
+1. ῆλθε, for Strong Aorist, see [REF].
+2. παντὰ τὰ ἐν τῇ Μολδοβλαχίᾳ *all the arrangements in Roumania*.
+3. τὸν Ὑψιλάντην στρατηγὸν προστάξαντες *appointing Hypsilantes general*. Participles in -ας are declined like πᾶς, and are given in the Vocabulary as adjectives.
+4.  Prince Alexander Hypsilantes had served in the Russian Imperial Guard, and had lost an arm at the battle of Culm in 1813; after the peace of 1815 he grew weary of inaction and entered warmly into the plans of the Hetairists.
+5. ὅς... ἀπέθανε *who had been put to death by the Turks on a charge of treachery*. The Aorist in a subordinate clause often refers to a time which is *past* from the point of view of the main clause; in these cases we use the Pluperfect in English. ὑπό, see [REFn].
+6. δ' οὖν. See [REFn].
+7. ἐς διακοσίους *to the number of 200*; a common use of ἐς with numerals.
+8. ὁμήρους ἔλαβον *seized as hostages*.
+9. δεσμοῖς lit. *with chains*, Instrum. Dat. [REFn].
+10. πλὴν ὅσοι ἀπέφυγον *except those who had escaped*.
+11. πλήν is also used as a Preposition, [REF].
+12. ἐπ' ἐλευθερίᾳ *to secure the freedom of the people*.
+13. ἥκει... μέλλει, *had come... intended*; notice that in noun-clauses introduced by ὅτι, the original tenses are retained; for instance, in the proclamation Hypsilantes said, *I am come... Russia intends*, therefore the Present tenses are retained, though we translate them by Past tenses. Cf. [REF], and passim.
+14. At the end of the proclamation came these words: "If some desperate Turks venture to make an incursion into your territory, fear nothing; for a Great Power is ready to punish their insolence". The "Great Power" was, of course, Russia.
+15. Instead of taking military precautions Hypsilantes commenced operations by seizing a wealthy banker whom he accused of being hostile to the Revolution and concealing funds belonging to the Hetairia. The first accusation was not a crime and the second was false; but the banker was glad to pay the prince several thousand pounds to escape out of his hands. This act of extortion alarmed the wealthy citizens, who, afraid of being robbed by the Greeks, availed themselves of every opportunity of escaping into Russia and Austria -FINLAY.
+16. ὡς εἶδον *when they saw*. For Augment, see [REF].
+17. ενόμιζόν τε *and they thought*; τε is here used as a conjunction, joining two sentences. Introd. Note A. (i.).
+18. οὐ μέλλει *was not likely*; for tense, see [REFn].
+19. εκεῖ. Introd. Note B. (iv.).
+20. τὰ τῶν ἐμπόρων. Introd. Note B. (ix.).
+21. καὶ αὐτοὶ τὸ αὐτὸ ἔπρασσον *themselves too did the same*. Cf. [REFn].
+22. αὐτός immediately preceded by the article means *same*.
+23. ἐκώλυον *tried to prevent*.
+
+### Section 6.
+
+ελπίς, [REF]; τις, [REF].
+
+1. μετά with Acc. *after*; with Gen. *with*, [REF].
+2. προύβαινε, for Augment, see [REF].
+3. εἴ τις καὶ ἄλλος... lit. *if any one else also of those in the conspiracy (was loyal)*, i.e., *was as loyal as any one*.
+4. ὕστερον *subsequently*, as related in [REF].
+5. τῶν ἐκ τῆς περιοικίδος. Introd. Note B. (ix.).
+6. χάριτι *by his influence*. Instrum. Dat. [REFn].
+7. ἐν ἐλπίδι... καταλύειν καὶ... ἀναλαβεῖν *he is in hopes of overthrowing... and recovering*. Notice that the Aor. Infin. does not refer to *past* time. See [REF].
+8. τῷ αὐτῷ, [REFn].
+9. ἐν παντὶ δὴ ἀταξίας... lit. *in everything of disorder*, i.e., *in a state of utter disorder and suspicion*. δὴ only emphasises πᾶς, cf. [REF].
+10. παρεῖχε, for Augment, see [REF].
+11. ὑπήκουον takes either the Gen. (as here) or the Dat. [REF].
+12. This Sacred Battalion consisted of about 500 Greeks; their uniform was black with a cross formed of bones in front and Constantine's inscription, *In hoc signo vinces*. -ALISON.
+
+### Section 7. 
+
+Pres. Ind. of ποιεῖν, ποιῶ, [REF].
+
+1. οὕτως εἶχε, with adverbs έχειν means *to be*; *when matters in the camp were in this condition*.
+2. ὑπ' ὀργῆς *angrily*.
+3. κρύφα αὐτοῦ *without his knowledge*.
+4. Besides disavowing the Insurrection, the Czar (Alexander I.) commanded Hypsilantes "to proceed no further, but on the contrary if possible to disband the unhappy men, whom you have misled". Hypsilantes pretended that the Russian proclamation was only a blind to deceive the Turks, and that the Czar was really sending troops to support him.
+5. στρατιᾷ *with an army*; the Instrumental Dative is very common in military phrases, expressing the accompanying force.
+6. ὅσα... Καραβιοῦ, see [REFn].
+7. ὑπό. See [REFn]. 
+8. τὴν τιμωρίαν... αναλαμβάνειν *to take vengeance on those who had committed the crime*. The Participle with the Article is equivalent to a noun, just as an adjective with the Article is; ὁ ἀδικήσας or ὁ ἄδικος = *the wrong-doer*.
+9. οἱ μετ' αὐτοῦ lit. *those with him*, i.e., *his troops*. Introd. Note B. (ix.).
+10. τοῦ Βουκουρεστίου *from Bukharest*. The Gen. in Greek expresses "separation," *from*, like the Lat. Abl. of Separation. Cf. [REFn].
+11. εἷλον, for Augment, see [REF].
+12. λαβεῖν... *to receive the governorship as the reward of his treachery*. Cf. [REFn].
+13. αὐτομολίᾳ χωρεῖν *to go by desertion*, i.e., *to desert*; αὐτομολίᾳ is Dat. of Manner, like Lat. Abl. of Manner.
+14. ὥστε *on condition of*; ὥστε often introduces the terms of an agreement.
+
+
+### Section 8. 
+
+Past Imperf. of ποιεῖν, ἐποίουν, [REF].
+
+1. εἶναι, Or. Obl., *he said he was disloyal*.
+2. ὑπό, [REFn]. Caravia and another officer butchered him in a barbarous way with their sabres.
+3. προσεχώρουν... *joined the Turks as deserters*.
+4. ες ὀκτακοσίους τινάς *to the number of some eight hundred*. Cf. [REFn].
+5. εδόκει τῷ Γεωργάκῃ *it seemed good to Georgaki*, i.e., *G. determined*. One of the reasons for postponing the engagement was the fact that the day was a Tuesday which is regarded as an unlucky day in the East.
+6. κύκλῳ *by a circuitous way*.
+7. ὥστε with Inf. gives the result, whether it is the actual or only the probable result; with the Ind. it gives the actual result only, [REF]; *so as to cut them off and prevent them escaping*.
+8. οὕτω... *in this way they were likely to kill them all*.
+9. ἔρρει, for Augment, see [REF].
+10. στάδια, the plur. of στάδιον is either στάδια or στάδιοι, [REF].
+
+
+### Section 9.
+
+1.  Caravia was always reckless, and on this occasion happened to be intoxicated. -GORDON.
+2. ήθελε... *he wished the glory of the victory to belong to his men*. εἶναι with Dat. is used to express "*belong to*" or 
+"*have*" like Lat. *est mihi liber*, *I have a book*.
+1. ἅμα τῇ ἑσπέρᾳ lit. *with the evening*, i.e., *at sunset*.
+2. ἅμα is often used as a prep. with words denoting "*time*".
+3. ἵππος *horse* is sometimes used as a collective noun, meaning *Cavalry*, just as we speak of So-and-so's Horse meaning "mounted regiment". ἵππος in this sense is fem.
+4. εἶδον is plur. because the "battalion" is regarded as "the soldiers"; so too καὶ αὐτοί in [REF]. Verbs of sense-perception (e.g., seeing, knowing, hearing, etc.) take the Acc. and Partic. in Greek, as they may do in English, *saw him advancing*.
+5. ἔργον *action*; used in Greek as we use *action* to denote *battle*.
+6. θυμῷ καὶ ῥώμῃ *with spirit and confidence*; Dat. of Manner. Cf. [REFn].
+7. έμελλον *they were on the point of leaving the village*. Cf. [REFn]. 
+8. οἱ ὁπλῖται, *viz*., the troops mentioned in [REF].
+9. δρόμῳ, Dat. of Manner. Cf. [REFn].
+10. ἔτρεπον *routed them*; τοὺς ἐναντίους is understood from τοῖς ἐναντίοις.
+11. ὡς εἰπεῖν *so to speak*; this phrase is used to apologise for an exaggeration; πάντας ὡς εἰπεῖν = *practically all*, not literally all. The Infin. εἰπεῖν is used absolutely, i.e., without any syntactical construction with the sentence.
+
+
+### Section 10. 
+
+οὗτος, [REF].
+
+1. ταῦτα *this*; οὗτος refers to what precedes, ὅδε refers to what is coming, [REF].
+2. ἔτυχον παραστάντες *happened to be standing near*; τυγχάνω takes the Participle where we use the Infinitive.
+3. ὅσοι... λόχου, see [REFn].
+4. οἱ δέ. Introd. Note B. (viii.).
+5. τῷ δ' Ὑψιλάντῃ ἀθυμία ἐνέπεσε *Hypsilantes became disheartened*. 
+6. ταύτης τῆς μάχης, οὗτος requires the article to be used before the noun, as ὅδε does. Cf. [REFn].
+7. τῇ ὑστεραίᾳ, sc. ἡμέρα, *on the next day*. When an event is dated by the particular *day, night, month* or *year* of its occurrence, the Dat. is used without a prep., otherwise the prep. ἐν is used.
+8. The proclamation began, "Soldiers! I can hardly bring myself to sully that honourable and sacred name by applying it to persons such as you. Henceforth every bond is severed between us; but I shall ever feel profoundly the shame of having been your chief." -ALISON
+9. ἐσπίπτει *is thrown into*; the Passive of compounds of βάλλειν *throw* is formed by the corresponding compounds of πίπτειν *fall*, e.g., ἐκβάλλω *I expel*, ἐκπίπτω *I am expelled*; cf. ἀποκτείνω *I kill*, ἀποθνῄσκω *I am killed*.
+10. αἱ ἀρχαί, Abstract for Concrete, *the Austrian authorities*.
+11. νόσῳ lit. *by disease*, Instrum. Dat. [REFn], *he fell ill and died*. Hypsilantes was kept as a prisoner until 1827, when he was released, but he died in the following year from the effects of imprisonment in unhealthy fortresses.
+12. ἐν goes with ἀπορίᾳ as well as with κινδύνῳ.
+13. ἐπ' οἴκου *homewards*, ἐπ' οἶκον *home*; ἐπί with Acc. states where one goes; with Gen. it states the direction only.
+14. ἐδόκουν *seemed*, ἐδόκει *it seemed good*; the two uses are the same as those of Lat. *videri*.
+15. εὑρεῖν. See [REFn].
+
+
+### Section 11. 
+
+φύλαξ, ἀγών, οἰκήτωρ, [REF].
+
+1. τοὺς στρατιώτας is the object of ἀπολείπειν, which can be used transitively, as here, or intransitively [REF] (απολείπειν ἐκ τοῦ ἀγῶνος *to desist from the struggle*).
+2. λαβεῖν, Or. Obl., *they considered that they had taken up arms*. Cf. [REF].
+3. ὥσπερ κλέπται πολεμεῖν *to carry on a guerilla warfare*. Cf. [REF].
+4. ὅσα... Τούρκων, see [REFn]. τῶν ἄλλων, masc.
+5. τάδε. Introd. Note A. (ii.).
+6. τῇ τρίτῃ ἡμέρᾳ. Cf. [REFn].
+7. θάτερα is a contracted form of τὰ ἔτερα, lit. *the other parts*, i.e., *the other side*.
+8. ἔνεον, for uncontracted form, see [REF].
+9. ὑπῆρχεν αὐτοῖς lit. *existed for them*, i.e., *they found a refuge*. Cf. [REFn].
+
+
+### Section 12.
+1. επὶ δύο μῆνας *for two months*; Duration of Time is expressed by the Acc. alone [REF] or with ἐπί.
+2. τέλος, as adverb, *at last*.
+3. Monasteries were often used during the war as fortresses, or places to store ammunition; in some cases the books they contained were destroyed to provide paper for cartridges.
+4. νυκτός *by night*. The Acc., Gen. and Dat. are all used to denote time. μέλλει μάχεσθαι τήνδε τὴν νύκτα, νυκτός, τῇδε τῇ νυκτί, *he intends to fight throughout this night, by night, on this night*. The Acc. implies that the fighting and the night last the same length of time; the Gen. implies that the night lasts longer than the fighting; the Dat. disregards duration altogether, and merely states that the night and the fighting occurred together. Cf. [REF].
+5. κήρυκα *a man with a flag of truce*.
+6. ἄδειαν ποιεῖν *to give a safe conduct to Georgaki and all the others who were there*. The clause ὅσοι... παρῆσαν is equivalent to πᾶσι τοῖς ἔνδον.
+7. Georgaki addressed his followers thus: "Brothers, in our present circumstances, a glorious death is all we ought to wish for, and I trust there is no one here base enough to regret his life. Let us imitate those true Greeks our comrades, whose dead bodies are stretched on the fields of Dragashan and Skuleni and whose blood yet cries for vengeance. If we die like them, perhaps on some future day our countrymen will gather up our bones, and transport them to the classic land of our forefathers." -GORDON.
+8. πύργον *the belfry*.
+9. ἐμπρήσας *having set it (the gunpowder) alight*.
+10. ἀφ' οὗ (sc. χρόνου) *from the time when*.
+11. Two reasons are given for the failure (i.) διὰ τήν τε ἀξυνεσίαν, and (ii.) ὅτι οὐκ ἐνόμιζον..., *owing to the folly of Hypsilantes and because the inhabitants did not think*, etc. It is very common in Greek to express two parallel ideas by two different syntactical constructions. Cf. [REF], where a noun and a rel. clause are parallel; and [REF], χαλεπῶς καὶ ἐν ὑετῷ where an adverb and a prepositional phrase are parallel.
+
+## Part 2
+
+[REFs] REFER TO SONNENSCHEIN'S GREEK GRAMMAR.
+
+### Section 13. 
+
+Pass. and Mid. Pres. of λύειν, Ind. λύομαι, Inf. λύεσθαι, Part. λυόμενος, [REFs]. Pres. Part. Act. of εἶναι, ὤν; of λύειν, λύων; Str. Aor. ἐλθών; all like ἑκών, [REFs], of ποιεῖν, ποιῶν, [REFs].
+
+1. πρὶν... ἐλθεῖν *before affairs in Roumainia came*.
+2. παρασκευάζονται... *get ready to meet the crisis*.
+3. The Middle Voice has a reflexive meaning, implying that the agent is working for or upon himself; in most cases English does not admit of this shade of meaning, and the Mid. is translated as if it was an active or neuter verb: e.g., βλύλονται *they wish* [REF], μάχεσθαι *to fight* [REF]. In some cases, however, the reflexive force is retained, παρασκευάζονται *they make themselves ready*; ἀμύνονται *they ward of from themselves*, i.e., *they defend themselves* [REF].
+4. Ὑψ. στρατηγοῦντος *under command of Hypsilantes*. The Gen. case is used Absolutely in Greek, like Lat. Abl. Abs.
+5. τὰ ὄντα *the things that are*, i.e., *the truth*.
+6. The Greeks were encouraged by several monks and hermits who issued from their cells and wrought on the superstition of the peasantry by visions and prophecies.
+7. γάρ often introduces a narrative, alluded to in the previous clause. In English no corresponding conjunction is used.
+8. ἔτυχον ἀποβάντες *happened to disembark*. Cf. [REFn].
+9. The Turkish armies were largely recruited from the Albanians, who enjoyed a high reputation for bravery.
+10. ἐς χαράδραν ἐνήδρευον *set an ambuscade in a ravine*; cf. Lat. *abdere se in silvam*.
+11. ἐς εἴκοσι. Cf. [REF].
+12. τούτων γενομένων. See [REF].
+13. μέλλουσαν *coming*.
+
+
+### Section 14. 
+
+Pass. and Mid. Pres. of ποιεῖν, Ind. ποιοῦμαι, Inf. ποιεῖσθαι, Part. ποιούμενος, [REFs]; ὄνομα, [REFs]; γένος, [REFs].
+
 1. οἱ ἐκ τῆς περιοικίδος Έλληνες.-Introd. Note B. (iv.).
 2. πεῖραν ποιοῦνται τοῦ τείχους make an attempt on the fort.
-3.  áμúver means to ward off, sc. Tous Toλeμious, the Mid. means to ward off for oneself, hence to defend oneself. Cf. 15, 3 n.
+3.  áμúver means to ward off, sc. Tous Toλeμious, the Mid. means to ward off for oneself, hence to defend oneself. Cf. [REFn].
 4.  βουλευομένοις πρὸς deliberating with regard to.
-5.  ὥστε . ¿¿eλÕéîv on condition that the Turks should march out. Cf. 10, 10 n.
+5.  ὥστε . ¿¿eλÕéîv on condition that the Turks should march out. Cf. [REFn].
 72 
 1.  ἐπὶ τούτῳ 
-NOTES TO PAGES 16, 17 
-on this condition they guarantee their lives. 22. ὡς ἀδύνατον ν since it was impossible in any other way. The Acc. is used absolutely (instead of the Gen.) with Impersonal verbs, or Neut. adj. with ov, see 1. 29 eυ πapaoxov there being a favourable opportunity, from Impersonal ev mapéxe there is a favourable opportunity. às is often used with Partic. or Prepositional phrases, to give the motive for the action expressed by the main verb. Cf. 17, 8, 20.
-1.  vipxe their numbers were not sufficient. Cf. 14, 2 n.
+NOTES TO PAGES [REF] 
+on this condition they guarantee their lives. 22. ὡς ἀδύνατον ν since it was impossible in any other way. The Acc. is used absolutely (instead of the Gen.) with Impersonal verbs, or Neut. adj. with ov, see 1. 29 eυ πapaoxov there being a favourable opportunity, from Impersonal ev mapéxe there is a favourable opportunity. às is often used with Partic. or Prepositional phrases, to give the motive for the action expressed by the main verb. Cf. [REF].
+1.  vipxe their numbers were not sufficient. Cf. [REFn].
 2.  See 1. 22 n.
 · 
 1.  Καλαμάταν . ἐπολιόρκουν lit. they besieged a place (χωρίον τι) Kalamata, as to its name. Καλαμάταν is in apposition to χωρίον, ὄνομά is Acc. of Respect.
-Page 17, 1. σπονδὰς ποιοῦνται 
+Page [REF]. σπονδὰς ποιοῦνται 
 = 
 σπένδονται. This periphrasis with 
 = 
-ποιεῖσθαι is extremely common; cf. 1. 7 εὐχὰς ποιοῦνται εὔχονται; 1. 29 λείαν ἐποιοῦντο = ελῄζοντο ; 1. 30 φυγὴν ἐποιοῦντο = ἔφευγον, and other instances in Vocab. 8.v. Toleiv. The Passive is formed by yiyveobai, e.g., ἀρχὴν ποιοῦνται τοῦ πολέμου they begin the war, ἀρχὴ τοῦ πολέμου yiyverai the war is begun. Cf. 15, 10.
-1. BOTE. See 16, 17 n.
+ποιεῖσθαι is extremely common; cf. 1. 7 εὐχὰς ποιοῦνται εὔχονται; 1. 29 λείαν ἐποιοῦντο = ελῄζοντο ; 1. 30 φυγὴν ἐποιοῦντο = ἔφευγον, and other instances in Vocab. 8.v. Toleiv. The Passive is formed by yiyveobai, e.g., ἀρχὴν ποιοῦνται τοῦ πολέμου they begin the war, ἀρχὴ τοῦ πολέμου yiyverai the war is begun. Cf. [REF].
+1. BOTE. See [REFn].
 2. Tŷ Túxn by their good fortune. Instrum. Dat.
 "On the 5th of April, 1821, the Greeks sang their first thanks to God for victory. The ceremony was performed on the banks of the torrent that flows by Kalamata. Twenty-four priests officiated and five thousand armed men stood round. Never was a solemn service of the Orthodox Church celebrated with greater fervour, never did hearts overflow with sincerer devotion to Heaven, nor with warmer gratitude to their church and their God. Patriotic tears poured down the cheeks of rude warriors, and ruthless brigands sobbed like children. All present felt that the event formed an era in the history of their nation."-FINLAY.
 1. às airíovs õvras as being the authors.
@@ -348,8 +369,8 @@ yevouévov of what had happened; the commonest Str. Aor. Mid. are ᾐσθόμη�
 NOTES TO PAGES 17-19 
 73 
 fathers had adopted the religion of Mahomet to avoid having to send their children as tribute to Constantinople.
-1.  λeíav éπoloûvтo they plundered. Cf. 17, 1 n.
-Page 18, 1. où διὰ μakpov (sc. xpóvov) lit. not at a great interval of time, i.e., soon.
+1.  λeíav éπoloûvтo they plundered. Cf. [REFn].
+Page [REF]. où διὰ μakpov (sc. xpóvov) lit. not at a great interval of time, i.e., soon.
 1. ἔχοντες 
 · 
 .. having the events at Kalamata as examples of all that they too were likely to suffer.
@@ -361,44 +382,44 @@ Section 16. Act. Fut. of Xue, Ind. λvow, Inf. Xvoew, Part. Xvowv, § 181. πό�
 3.  δι' ὧν . . . ἐπράσσοντο by whose agency they raised the taxes. 16. ås BovλevσovTes to deliberate; the Fut. Partic. expresses purpose as in Latin.
 • 
 • • 
-ἐν ἀξιώματι ἦσαν ὑπό were held in honour by. Cf. 5, 16. 18. no@ávovтo... lit. perceived the Greeks that they were preparing, i.e., perceived that the Greeks were preparing.
-1.  ἐσκόπουν ὅπως . . . κωλύσουσι considered how they should prevent. Ind. Question; the tense and mood of the original question "How shall we prevent?" are retained, just as is the case with ori. Cf. 7, 28 n.
+ἐν ἀξιώματι ἦσαν ὑπό were held in honour by. Cf. [REF]. 18. no@ávovтo... lit. perceived the Greeks that they were preparing, i.e., perceived that the Greeks were preparing.
+1.  ἐσκόπουν ὅπως . . . κωλύσουσι considered how they should prevent. Ind. Question; the tense and mood of the original question "How shall we prevent?" are retained, just as is the case with ori. Cf. [REFn].
 Anvel, Instrum. Dat., by the taking.
 1.  οὐ προυχώρει 
 • 
-matters did not proceed as they wished. 28. ἄριστα ἕξει τὰ πράγματα matters would be best; ἄριστα is an adverb. Cf. 9, 13 n.
+matters did not proceed as they wished. 28. ἄριστα ἕξει τὰ πράγματα matters would be best; ἄριστα is an adverb. Cf. [REFn].
 1.  For omission of conjunction see Introd. Note A. (ii.).
-Page 19, 2. Ek πapaσкevĤs by arrangement.
+Page [REF]. Ek πapaσкevĤs by arrangement.
 1. προσεποιοῦντο 
 they pretended (a) that a letter had come ..., 
 and (b) that he advised them.
 • 
 For the two different constructions 
-(i.) Acc. and Inf. (ii.) or clause, see 14, 28 n.
+(i.) Acc. and Inf. (ii.) or clause, see [REFn].
 1. μελλόντων 
 • 
 since the government intended to kill them all.
-oi év ápxaîs = ai ȧpxaí, 12, 27.
-1.  ἐπ ̓ οἴκου means in the direction of home, homewards 1. 1 ἐπὶ τῆς πόλεως: ἐπ ̓ οἶκον 1. 6 means home, implying that you get there. Cf. 13, 2 n.
+oi év ápxaîs = ai ȧpxaí, [REF].
+1.  ἐπ ̓ οἴκου means in the direction of home, homewards 1. 1 ἐπὶ τῆς πόλεως: ἐπ ̓ οἶκον 1. 6 means home, implying that you get there. Cf. [REFn].
 74 
 NOTES TO PAGES 19-21 
 Section 17. Act. Weak Aor. of λveiv, Ind. ëλvoa, Inf. Xvoai, Part. λύσας, § 182. βασιλεύς, § 37. μέγας, § 105.
-1.  διὰ τὸ . . . ἔχειν owing to his regarding all alike with suspicion. The Article with the Infin. forms a noun-equivalent. It can be used in any case (Dat. 1. 26; Nom. 20, 4) and is especially common after prepositions. The Infin. may have a subject, or object (as rávτas), and may be qualified by any adverbs (as ouoíws) or adverb-equivalents (as év vπovía), just as is the case with any other use of the Infin.
+1.  διὰ τὸ . . . ἔχειν owing to his regarding all alike with suspicion. The Article with the Infin. forms a noun-equivalent. It can be used in any case (Dat. 1. 26; Nom. [REF]) and is especially common after prepositions. The Infin. may have a subject, or object (as rávτas), and may be qualified by any adverbs (as ouoíws) or adverb-equivalents (as év vπovía), just as is the case with any other use of the Infin.
 2.  μéya тi πрâyμa πpáşavra lit. having done some great deed, i.e., by some violent measure.
 3.  τῷ Evλλaßeiv by arresting them. Cf. 1. 20 n.
 • 
 1.  The Chief Dragoman and Secretary were important Turkish officials.
-Page 20, 4. rò μǹ vñakovew lit. the not-obeying, i.e., disobedience. See 19, 20 n.
+Page [REF]. rò μǹ vñakovew lit. the not-obeying, i.e., disobedience. See [REFn].
 1. βασιλέως 
 = 
 Σουλτάνου.
-1.  ròv yàp Baoiλéa, Or. Obl. Cf. 10, 16.
-2.  διὰ To Tηv éoprǹv äyeɩ because of their keeping the festival. See 19, 20 n. Gregory was arrested on Easter Eve.
-3.  čruxov ronoovres happened to be going to celebrate. Cf. 15, 11. 19. Sultan Mahmud II. was called "the Butcher" by the Greeks after this murder. Gregory was 82 years old at the time of his execution. There is no reason to suppose that he was inculpated in the conspiracy. At all events he had solemnly excommunicated Hypsilantes when the news of the insurrection in Roumania reached Constantinople.
+1.  ròv yàp Baoiλéa, Or. Obl. Cf. [REF].
+2.  διὰ To Tηv éoprǹv äyeɩ because of their keeping the festival. See [REFn]. Gregory was arrested on Easter Eve.
+3.  čruxov ronoovres happened to be going to celebrate. Cf. [REF]. 19. Sultan Mahmud II. was called "the Butcher" by the Greeks after this murder. Gregory was 82 years old at the time of his execution. There is no reason to suppose that he was inculpated in the conspiracy. At all events he had solemnly excommunicated Hypsilantes when the news of the insurrection in Roumania reached Constantinople.
 Section 18. γλυκύς, § 102. πολύς, § 105.
 1.  The feelings with which the Jews and Greeks regarded one another may be illustrated by this extract from Gordon: "A band of Jews attended the Pasha's camp voluntarily in the capacity of executioners, allured merely by the pleasure of butchering with clubs the Greek prisoners. One of these execrable savages afterwards boasted that in a single day he had with his own hands slaughtered sixty-four victims.
 "" 
-Page 21, 1. Greek priests wear beards, while other Greeks do not, hence it was easy to recognise the body.
+Page [REF]. Greek priests wear beards, while other Greeks do not, hence it was easy to recognise the body.
 1. ὥσπερ θείᾳ τύχῃ providentially. 13. οὐ χαλεπόν 
 suffered.
 it is not hard to imagine all that the Greeks 
@@ -408,11 +429,11 @@ Section 19. Act. Perf. of Xúew, Ind. λevka, Plup. λeλúкn, Inf. λeλvkéva
 peλovra find that the people were on the 
 NOTES TO PAGES 21-23 
 75 
-point of holding an assembly. Verbs of finding and sense-perception (perceiving, seeing, knowing) take the Participle instead of the Infinitive. Cf. 11, 25 n.
-1.  is Telow to persuade. Cf. 18, 16 n.
+point of holding an assembly. Verbs of finding and sense-perception (perceiving, seeing, knowing) take the Participle instead of the Infinitive. Cf. [REFn].
+1.  is Telow to persuade. Cf. [REFn].
 2.  Teixiopara. The fortresses in the Peloponnese still held by the Turks were Nauplia, Navarino, Modon, Coron, Monemvasia, Patras and Tripolitza.
-Page 22, 4. τοὺς νησιώτας καὶ ὅσοι 
-eioiv. Cf. 14, 28 n. 7. ἀπ' αὐτῶν = ἀπὸ τῶν κινδύνων which will result there from. 8. ὅσα . ἡμαρτήκασι the crimes of the Turks; so ὅσα πεπόνθαμεν 
+Page [REF]. τοὺς νησιώτας καὶ ὅσοι 
+eioiv. Cf. [REFn]. 7. ἀπ' αὐτῶν = ἀπὸ τῶν κινδύνων which will result there from. 8. ὅσα . ἡμαρτήκασι the crimes of the Turks; so ὅσα πεπόνθαμεν 
 our sufferings.
 1.  πάντων ὧν ἐπεπόνθεσαν for all they had suffered. ὧν is attracted into the case of its Antecedent návrov; this attraction occurs when the Relative Pron. would naturally be in the Acc. and its Antecedent is in the Gen. or Dat.
 21 n.
@@ -422,7 +443,7 @@ Section 20. Fut. Mid. of Xve, Ind. Xvooμai, Inf. λvoeσbai, Part. λυσόμε
 1.  The inhabitants of Psara, Spetza, and Hydra supplied sailors to man the Sultan's fleet, as well as paying a small tribute.
 2.  τὰ δὲ ἄλλα . . in other respects they were free citizens.
 3.  During the wars which followed the French Revolution, the crews often doubled their capital by carrying grain from the Bosphorus to the blockaded towns.
-Page 23, 4. dógav Acc. Abs. from Impersonal dokeî it seems good :— since they had determined. Cf. 16, 22 n.
+Page [REF]. dógav Acc. Abs. from Impersonal dokeî it seems good :— since they had determined. Cf. [REFn].
 • 
 • 
 • 
@@ -436,55 +457,55 @@ Section 21. Weak Aor. Mid. of Ave, Ind. Avσáμny, Inf. λvoaodai, Part. Avoάu
 NOTES TO PAGES 23-26 
 remarked on one occasion that they would be more formidable if they did not take aim.
 1.  γνώμην ἐποιήσατο proposed.
-Page 24, 3. éyéμoav kλŋparidwv they filled with brushwood. 10. és rò... getting into the small boat they rowed away.
+Page [REF]. éyéμoav kλŋparidwv they filled with brushwood. 10. és rò... getting into the small boat they rowed away.
 1.  où yàp hv for it was not possible.
 • 
-1.  διὰ τὸ πpoσéxew owing to the enemy paying attention. Cf. 19, 20 n. On several other occasions Canaris repeated the exploit here described.
+1.  διὰ τὸ πpoσéxew owing to the enemy paying attention. Cf. [REFn]. On several other occasions Canaris repeated the exploit here described.
 2.  The Greeks excused these murders on the ground that they were avenging Gregory's execution.
-Section 22. Pass. Weak Aor. of λvew, Ind. ‹λúðŋy, Inf. λvôĥvai, Part. λυθείς, §§ 183, 108 (3); Fut. Ind. λυθήσομαι, Ιnf. λυθήσεσθαι, Part. λυθησόμενος, § 183.
+Section 22. Pass. Weak Aor. of λvew, Ind. ‹λúðŋy, Inf. λvôĥvai, Part. λυθείς, §§ [REF] (3); Fut. Ind. λυθήσομαι, Ιnf. λυθήσεσθαι, Part. λυθησόμενος, § 183.
 1.  TOUTWV.-Introd. Note A. (ii.).
 2.  Demetrius Hypsilantes is thus described by Gordon: "Nature had favoured him more in mind than in his corporeal frame, for his diminutive stature, bald head, awkward carriage, and indistinct utterance, were ill-calculated to win the opinions of those who beheld him. On the other hand it was difficult to know without esteeming him, for even his enemies were forced to confess, that to ardent patriotism he united courage, integrity and humanity, disregarded the allurements of pleasure, and had much goodness of heart, with a steadiness of purpose which at times bordered upon obstinacy." 
 "Colokotrones, like his father, had been a clepht. Tall and athletic, with a profusion of black hair and expressive features, alternately lighted up with boisterous gaiety, or darkened by bursts of passion : among the soldiers he seemed born to command, having just the manners and bearing calculated to gain their confidence." 
-Page 25, 8. v. Cf. 22, 13 n.
+Page [REF]. v. Cf. [REFn].
 1.  τῶν παρόδων 
-ἐσκομισθήσεται to keep watch on the passes to prevent supplies being sent in. Cf. 23, 9 n.
+ἐσκομισθήσεται to keep watch on the passes to prevent supplies being sent in. Cf. [REFn].
 1.  The camp was situated at Valtetzi, several miles south of Tripolitza.
 2.  The moral effect of this victory in encouraging the Greeks was out of all proportion to the losses actually inflicted on the Turks, which amounted to about 400 men.
 Section 23. ȧvýp, § 49 (1); yvvý, § 49 (5).
-Page 26, 14. hy it was possible. Cf. 24, 13.
+Page [REF]. hy it was possible. Cf. [REF].
 • 
 1.  εἴ τινες · if any were known to them, i.e., they sent to any of those inside whom they knew, 
-NOTES TO PAGES 26, 27 
+NOTES TO PAGES [REF] 
 77 
-1.  ἐπὶ τῷ 16, 19 n.
+1.  ἐπὶ τῷ [REFn].
 • 
-δέxeobai on condition of receiving. Cf. 19, 20 n; 
+δέxeobai on condition of receiving. Cf. [REFn]; 
 1.  The report that a Turkish army was coming turned out to be false.
 Section 24. Pass. and Mid. Perf. Ind. of Xúeiv, δέλvpai, Plup. ἐλελύμην, Ιnf. λελύσθαι, Part, λελυμένος, § 183.
-Page 27, 4. év TO NEOKáσTрo. Navarino had capitulated on 19th Aug. and a dispute arose about searching the Turkish women for jewels which they were supposed to have concealed. "Women wounded with musket balls and sabre cuts rushed to the sea seeking to escape and were deliberately shot. Greeks seized infants from their mothers' breasts and dashed them against the rocks. Children, three and four years old, were hurled living into the sea and left to drown. When the massacre was ended, the dead bodies washed ashore or piled on the beach threatened to cause a pestilence. Phrantzes (a Greek priest) who records these atrocities of his countrymen with shame and indignation, himself hired men to burn the bodies of the victims with the wrecks of some vessels in the harbour."-FINLAY.
+Page [REF]. év TO NEOKáσTрo. Navarino had capitulated on 19th Aug. and a dispute arose about searching the Turkish women for jewels which they were supposed to have concealed. "Women wounded with musket balls and sabre cuts rushed to the sea seeking to escape and were deliberately shot. Greeks seized infants from their mothers' breasts and dashed them against the rocks. Children, three and four years old, were hurled living into the sea and left to drown. When the massacre was ended, the dead bodies washed ashore or piled on the beach threatened to cause a pestilence. Phrantzes (a Greek priest) who records these atrocities of his countrymen with shame and indignation, himself hired men to burn the bodies of the victims with the wrecks of some vessels in the harbour."-FINLAY.
 1.  Colokotrones records in his Memoirs that when he rode into the town his horse "from the walls to the palace never touched the earth,” owing to the accumulation of dead bodies.
 2.  τοὺς ἔνδον ἀποκτείνοντες ἐπέπαυντο, lit. murdering the inhabitants they had then desisted.
 3.  εἴ τι παρελέλειπτο 
 they plundered all that had been left. Some of the richest families in Greece to-day owe the foundation of their fortunes to the spoil of Tripolitza.
 1.  "After the Greeks had been in possession of the city for fortyeight hours, they deliberately collected together about 2,000 persons of every age and sex, but principally women and children, and led them to a ravine in the nearest mountain, where they murdered every soul. . . Some prisoners were spared for a short time to bury the bodies of their slaughtered countrymen, which were putrefying by thousands in almost every house and garden. Even this precaution was too long neglected. The air was already tainted with a deadly miasma and a terrible epidemic soon broke out among the Greeks."-FINLAY.
 78 
-NOTES TO PAGES 29, 30 
+NOTES TO PAGES [REF] 
 PART III.
 Section 25. Act. Subj. Pres. of eivai, &, § 266; of λúeiv, dúw, § 181 ; Wk. Aor., λύσω, § 182; Str. Aor. of πάσχειν, πάθω ; Pres. of ποιεῖν, ποιῶ, § 198.
-Regular Compar. of Adj., §§ 110, 111, 113 and Adverbs, § 173.
-Page 29, 1. áμа тô hρi áрxoμένe with the beginning of the spring (see cap). The Partic. is used as in Latin ante urbem conditam: Oépos summer includes spring and autumn, and is used of the whole period during which military operations were carried on in ancient times.
+Regular Compar. of Adj., §§ [REF] and Adverbs, § 173.
+Page [REF]. áμа тô hρi áрxoμένe with the beginning of the spring (see cap). The Partic. is used as in Latin ante urbem conditam: Oépos summer includes spring and autumn, and is used of the whole period during which military operations were carried on in ancient times.
 · 
 · 
-1. ὅπως ἐσαγάγωσιν in order to introduce; όπως (or iva) in order that with the Subj. expresses purpose. The Aor. in the Subj. Optat. and Imperat. moods is not a past tense: the difference between it and the present is not a difference in time but in kind of action ; the present regards the action as continuing, the Aorist regards it simply as occurring. Cf. p. 150.
+1. ὅπως ἐσαγάγωσιν in order to introduce; όπως (or iva) in order that with the Subj. expresses purpose. The Aor. in the Subj. Optat. and Imperat. moods is not a past tense: the difference between it and the present is not a difference in time but in kind of action ; the present regards the action as continuing, the Aorist regards it simply as occurring. Cf. [REF].
 2. Twν výσwν Kрarnbeir@v, Gen. Abs. expressing a condition, if the islands were conquered.
-3. ἐπικινδυνοτάτην εἶχον. See 5, 11 κ.
+3. ἐπικινδυνοτάτην εἶχον. See [REF] κ.
 4.  εὐτυχήσαντες. See Sect. 21.
 5.  avrov than they were. The Gen. of Comparison is used like the Latin Abl. of Comparison; it is a Gen. of Separation, laxuρÓTEρOL aurav meaning stronger starting from them.
 6.  Tois nãσi Evrорwтárny excellently provided with everything. "Celebrated for its fertility and the enchanting aspect of its gardens, Chios carried on a brisk trade in silk and fruit; from thence Constantinople was supplied with oranges, lemons and citrons; but the most valuable production of the country is gum mastic, a substance highly valued by Eastern ladies, who amuse their indolence by chewing it, deriving from that practice as much gratification as their male relations enjoy by inhaling the fumes of tobacco."-GORDON.
 7.  poßoúμevo un пábwσi fearing that they would suffer. The object clauses after words of fearing are introduced by μn lest, followed by the subj.
 8.  Antonius Bournia had previously served in the French army. 20. ἐποτρύνωσι. See l. 3 n.
-Page 30, 9. etre perexwo whether they should take part in the war. The subj. is used in Deliberative Questions, as in Latin.
-1.  devov v there was danger lest. Cf. 29, 16 n.
+Page [REF]. etre perexwo whether they should take part in the war. The subj. is used in Deliberative Questions, as in Latin.
+1.  devov v there was danger lest. Cf. [REFn].
 Section 26. Irreg. Compar. of Adj., §§ 117-119 and Adv., § 175. βελτίων, § 120.
 1.  ως is used for οὕτως in the expressions καὶ ὥs even 80, οὐδ ̓ ὦς not 
 even 80.
@@ -492,11 +513,11 @@ NOTES TO PAGES 30-33
 79 
 1.  or, or as (1. 21), is used with superlatives of adj. or adv. meaning as much as possible, like Latin quam.
 2.  πрiv 8 égeλeiv before they captured it.
-Page 31, 3. Told by much, i.e., far more powerful. 5. ἀσθενέστεροι ἢ ὥστε lit. weaker than so as to weak to defend themselves.
+Page [REF]. Told by much, i.e., far more powerful. 5. ἀσθενέστεροι ἢ ὥστε lit. weaker than so as to weak to defend themselves.
 1.  ǹ as.
 • 
 ., i.e., too 
-1.  Karà xiλious a thousand at a time; Distributive use of kará. 14. is eiπeiv. See 12, 6 n.
+1.  Karà xiλious a thousand at a time; Distributive use of kará. 14. is eiπeiv. See [REFn].
 2.  éπì dovλeia for slavery, i.e., to be slaves.
 It is said that out of 100,000 inhabitants of Chios, nearly a third was massacred, and nearly the half enslaved, only 1,800 were still living on the island in August, 1822.
 Section 27. Act. Optat. Pres. of Ave, Avoyu, § 181; Str. Aor. οἱ πάσχειν, πάθοιμι. Numerals, § 122. εἰς, δύο, τρεῖς, τέσσαρες, of § 123.
@@ -504,18 +525,18 @@ Section 27. Act. Optat. Pres. of Ave, Avoyu, § 181; Str. Aor. οἱ πάσχε�
 2.  The Albanian Christians, who lived at Souli, had fought on the side of Ali Pasha of Janina; when Ali was killed (Feb., 1822), they had continued the war with some success under Marcus Botzares, but were now being besieged in the Castle of Kiapha, which is the Acropolis of Souli.
 3.  Tapéxou. After an historic tense (Bouλero) the Optative may be used (instead of the Subj.) in final clauses, and with verbs of fearing.
 4.  γνώμῃ 
-inferior to no one in judgment; ovdevós is Gen. of Compar. See 29, 13 n.
+inferior to no one in judgment; ovdevós is Gen. of Compar. See [REFn].
 The corps, 
-Page 32, 6. The Philhellenes were officers from various European countries, who had volunteered for service in Greece. consisting of about 100 men, was formed to show the Greeks the value of discipline.
-1. yévos by race. Acc. of Respect. Cf. 16, 30.
+Page [REF]. The Philhellenes were officers from various European countries, who had volunteered for service in Greece. consisting of about 100 men, was formed to show the Greeks the value of discipline.
+1. yévos by race. Acc. of Respect. Cf. [REF].
 2.  Gogos had greatly distinguished himself in the previous year by repulsing a Turkish attack on Peta.
-3.  φοβούμενος μή EXOLEV. See 31, 25 n.
+3.  φοβούμενος μή EXOLEV. See [REFn].
 • 
 1.  ei. . . κaðégovor if they should control the administration of affairs.
 2.  oi δέ the Turks. Cf. Introd. Note B. (viii.).
 Section 28. Act. Optat. Weak Aor. of Xúew, Xvoa, § 182.
 • 
-Page 33, 9. τὸ πολύ ἐξέλθοιεν bear the brunt of the attack.
+Page [REF]. τὸ πολύ ἐξέλθοιεν bear the brunt of the attack.
 fearing that they would no longer effect anything.
 1.  δείσας 
 80 
@@ -523,20 +544,20 @@ NOTES TO PAGES 33-36
 1.  Most of the Turkish army had been recruited in Albania.
 2.  When two Rel. clauses, referring to the same antecedent (here Aópov), stand side by side, and the second Relative would be in a different case from the first (here first Rel. is ov and second would be ds), the second Rel. is either omitted (as here), or replaced by a Personal Pronoun. Cf. St. Matt. iii. 12, whose fan is in his hand, and he (not who) will throughly purge his floor.
 3.  ὡς σωτηρίας . as each group had hope of safety.
-Page 34, 1. roîs de λonoîs with the rest. Cf. 9, 19 n.
+Page [REF]. roîs de λonoîs with the rest. Cf. [REFn].
 1. ovdeμiâs éláσowv less than none, i.e., worse than any of the calamities in the war.
 2.  The remnant of the Philhellenes was disbanded shortly afterwards. The following incident is related by Gordon: "At noon on 16th July, as Mavrocordato sat at dinner with his suite at Langada, one of the Greek commanders, examining the shoulder-blade of a sheep according to a method of divination practised in the East, declared that their friends had suffered a bloody defeat; this caused some mirth at the seer's expense, until a horseman, while they were still at table, brought news of the battle of Peta". Two days after the battle Gogos went over to the enemy. Some of the Souliotes continued to fight on the Greek side under M. Botzares. See Sect. 35.
 3.  Corcyra (Corfu) was neutral territory, being under the control of an English High Commissioner.
 Section 29.
 1.  There were no houses in Salamis for the accommodation of these refugees, and the landowners showed their patriotism by exacting rent for the privilege of sleeping under an olive-tree.
-Page 35, 5. Bpaxéa eixov had their supplies short, i.e., were short of supplies. Cf. 5, 11 n.
+Page [REF]. Bpaxéa eixov had their supplies short, i.e., were short of supplies. Cf. [REFn].
 1. ὅπερ id quod.
 2.  oσov où almost, Lat. modo non.
 3.  äλdoi äλda ëλeyov, Lat. alius alia dicebant.
 Section 30. yw, σú, § 128. Act. Imperat. Mood of eivai, lobi, § 266; of λύειν, Pres. λνε, § 181 ; of ποιεῖν, ποίει, § 198; Wk. Aor. of λύειν, λύσον, § 182; Str. Aor. of πάσχειν, πάθε.
 1.  palóvrov let them learn. The 3rd Pers. Plur. of Imperatives is the same in form as the Gen. Plur. of the Participle.
 2.  ĕxovraι kaì ai vñσo the islands too are in their hands; the Present is used graphically for the Future.
-Page 36, 1. τίνα ἐλπίδα ἔχοντες 
+Page [REF]. τίνα ἐλπίδα ἔχοντες 
 .
 • 
 with what hope or with what 
@@ -553,7 +574,7 @@ purpose? The interrogative rís; who? is declined like the indefinite Tis any on
 8.  Evμßýσerai ημiv will happen to us, i.e., will be achieved by us.
 Section 31. Reflex. Pronouns éavróv, opeîs, § 134; Pass. and Mid. Subj. Pres. of λύειν, λύωμαι, § 183 ; of ποιεῖν, ποιῶμαι, § 199 ; Str. Aor. Μid. of γίγνεσθαι, γένωμαι.
 = 
-Page 37, 1. rà opérepa avrâv sua, their own property. opérepos is used (i.) as a Direct Reflexive, referring to the subject of the verb in its own clause, or (ii.) as an Indirect Reflexive, used in a Subordinate clause, and referring to the Subject of the main verb. If avrov is added, it is a Direct Reflexive only.
+Page [REF]. rà opérepa avrâv sua, their own property. opérepos is used (i.) as a Direct Reflexive, referring to the subject of the verb in its own clause, or (ii.) as an Indirect Reflexive, used in a Subordinate clause, and referring to the Subject of the main verb. If avrov is added, it is a Direct Reflexive only.
 1. τοὺς ἑαυτοῦ his own men.
 2.  raúry there.
 3.  opas is an Indirect Reflexive, used in a Subordinate clause and referring to the Subject of the main verb.
@@ -563,7 +584,7 @@ there was not much time and Colokotrones arrived, i.e., it was not long before C
 2.  oi ek twv μereάpwv, we should say those on the hills; Greek often accommodates the prepos. to the sense of motion expressed in the verb the men came down from the hills.
 3.  ἀσφάλεια τῆς ἐξόδου come away in safety.
 that Hypsilantes and his men might 
-Page 38, 2. On the second occasion, one of the Greeks happened to be asleep when his companions evacuated the fort, and was accidentally left behind. Awakened by the noise of the Turks rushing in to plunder, he seized a large copper cauldron, and, putting it over his head to conceal his features, walked boldly out. The Turks, thinking he was one of themselves carrying off loot, let him pass with a few jokes at his ridiculous appearance.-TRICOUPI.
+Page [REF]. On the second occasion, one of the Greeks happened to be asleep when his companions evacuated the fort, and was accidentally left behind. Awakened by the noise of the Turks rushing in to plunder, he seized a large copper cauldron, and, putting it over his head to conceal his features, walked boldly out. The Turks, thinking he was one of themselves carrying off loot, let him pass with a few jokes at his ridiculous appearance.-TRICOUPI.
 6 
 82 
 NOTES TO PAGES 38-40 
@@ -572,7 +593,7 @@ Section 32. doris, § 162. Wk. Aor. Subj. of λúeiv, Pass. λvbw, Mid. λύσω
 2. The Turkish fleet which should have brought supplies sailed away to Patras owing to the Admiral's jealousy of Dramali.
 • 
 1.  τὰ τῶν πολεμίων . seeing the affairs of the enemy in what state they are, i.e., seeing in what state the enemy are.
-For the order of words, by which rà râv Toλeμíov is made the Object of idóvres instead of being placed in the dependent clause as Subject, compare St. Mark i. 24, I know thee who thou art. oris introduces an Indirect Question ; the Direct Question was ἐν τίνι ἐστὶ τὰ τῶν πολεμίων ; in what state are the enemy's affairs? Greek retains the original tense (éori), just as it does in or clauses. See 7, 28 n.
+For the order of words, by which rà râv Toλeμíov is made the Object of idóvres instead of being placed in the dependent clause as Subject, compare St. Mark i. 24, I know thee who thou art. oris introduces an Indirect Question ; the Direct Question was ἐν τίνι ἐστὶ τὰ τῶν πολεμίων ; in what state are the enemy's affairs? Greek retains the original tense (éori), just as it does in or clauses. See [REFn].
 Dramali's difficulties were much increased owing to the season being singularly dry. Disease broke out among his men, who were living mainly on green grapes and unripe melons.
 1.  οἵτινες 
 ποιήσονται to make an ambuscade : ὅστις with Fut.
@@ -581,9 +602,9 @@ Indic. expresses purpose.
 2.  ποιήσωνται 
 • 
 • 
-κρατήσειαν, after an historic tense, όπως may take the Subj. (29, 3 n.) or the Optat. (31, 25 n.); occasionally, as here, both are used: there is no difference in meaning.
+κρατήσειαν, after an historic tense, όπως may take the Subj. ([REFn].) or the Optat. ([REFn].); occasionally, as here, both are used: there is no difference in meaning.
 1.  hy it was possible.
-Page 39, 5. oжоi тpáñwvrai where to turn; Delib. Subj., see 30, 
+Page [REF]. oжоi тpáñwvrai where to turn; Delib. Subj., see 30, 
 9 n.
 και 
 • • 
@@ -596,38 +617,38 @@ Section 33.
 2.  τοὐναντίον 
 guarding.
 • 
-πрáyμara seeing the state of affairs. Cf. 9, 13 n.
+πрáyμara seeing the state of affairs. Cf. [REFn].
 the opposite way to that which the enemy were 
-1.  oirives since they; ooris, besides being an Indirect Interrogative Pronoun, is used (i.) to express cause, as here; (ii.) with Fut. Ind. to express purpose, 38, 14 n.; and (iii.) as an Indefinite Rel. Pron. meaning whoever, 1. 19.
+1.  oirives since they; ooris, besides being an Indirect Interrogative Pronoun, is used (i.) to express cause, as here; (ii.) with Fut. Ind. to express purpose, [REFn].; and (iii.) as an Indefinite Rel. Pron. meaning whoever, 1. 19.
 2.  το πολύ 
 = 
 oi rooi the majority.
-Page 40, 5. The state of these fugitives is thus described by Gordon : "The famishing soldiers, after eating all their horses, existed on the flesh of their dead comrades, and even fought over their graves", 
+Page [REF]. The state of these fugitives is thus described by Gordon : "The famishing soldiers, after eating all their horses, existed on the flesh of their dead comrades, and even fought over their graves", 
 NOTES TO PAGES 40-43 
 83 
 Section 34. Pass. and Mid. Optat. Pres. of Xúeiv, Avoiμnv, § 183; οι ποιεῖν, ποιοίμην, § 199; Str. Aor. Mid. of γίγνεσθαι, γενοίμην.
 1.  These Albanians were Christians, serving as mercenaries to the Turks. They spoke the same dialect and wore the same dress as M. Botzares and his Souliotes.
-2.  For M. Botzares, see 31, 24 n.
-3.  πεῖραν ποιεῖσθαι, see 16, 9 η.
-4.  ἂν ἐπιφέροιντο they would attack; ἂν gives to the Optative s Potential sense, expressed in English by would, might or could. Page 41, 7. öпоi тρáπото where to turn; after an historic tense, the Optat. may be substituted for the Delib. Subj. in Indirect Questions. The original question was roî rparwμela; where are we to turn? Cf. 39, 5.
+2.  For M. Botzares, see [REFn].
+3.  πεῖραν ποιεῖσθαι, see [REF] η.
+4.  ἂν ἐπιφέροιντο they would attack; ἂν gives to the Optative s Potential sense, expressed in English by would, might or could. Page [REF]. öпоi тρáπото where to turn; after an historic tense, the Optat. may be substituted for the Delib. Subj. in Indirect Questions. The original question was roî rparwμela; where are we to turn? Cf. [REF].
 Section 35. Pass. and Mid. Imperat. Pres. of λúeiv, λvov; Wk. Aor. Mid. λῦσαι ; Wk. Aor. Pass. λύθητι, § 183 ; Str. Aor. Mid. of γίγνεσθαι, γένου ; Pres. of ποιεῖν, ποιοῦ, § 199.
 1.  avrov on the spot.
-Page 42, 2. oirives since they. Cf. 39, 17 n.
-1.  μn éкπλaynτe do not be alarmed. See 36, 5 n.
+Page [REF]. oirives since they. Cf. [REFn].
+1.  μn éкπλaynτe do not be alarmed. See [REFn].
 2.  πλήθει ελάσσους inferior in numbers.
 3.  un avopeious ovo if we are not brave; the Neg. is μn (not oỷ), because the Participle expresses a condition.
-4.  πρὸς ἡμῶν on our side. Cf. 36, 25.
+4.  πρὸς ἡμῶν on our side. Cf. [REF].
 5.  Teρì rλeiorov moɩîode, lit. regard above very much, i.e., regard as of the greatest importance.
 Section 36. Optat. Pres. of eivai, einv, § 266; Optat. Wk. Aor. Ρass. οἱ λύειν, λυθείην, Μid. λυσαίμην, Fut. λυσοίμην, § 183.
 1.  ei Bovλoμένo poí èori, lit. whether it is to me being willing, i.e., whether I am willing; compare Lat. quibus bellum volentibus erat.
 2.  δέxeσbai Tŷ móλei admit into the city; the Dat. Tóλe is Instrumental, literally, receive with the city; the Instrum. Abl. in Lat. is used similarly with recipere.
-3.  ǎoμevos âv dekaiμŋv I would gladly admit him: we translate the predicated Adjective douevos by an Adverb. Cf. Lat. primus hoc feci, I did it first, and reλevraîos, 35, 21.
+3.  ǎoμevos âv dekaiμŋv I would gladly admit him: we translate the predicated Adjective douevos by an Adverb. Cf. Lat. primus hoc feci, I did it first, and reλevraîos, [REF].
 4.  após in answer to.
-Page 43, 2. Tepì râv 'Eλλŋvikov with regard to the Greek War; τὰ  ̔Ελληνικά is the subject of μέλλει. See 38, 10 η.
+Page [REF]. Tepì râv 'Eλλŋvikov with regard to the Greek War; τὰ  ̔Ελληνικά is the subject of μέλλει. See [REF] η.
 1. Karapaivoivтo are in sight. In a clause introduced by ori (that), the Optat. may be substituted for the original Indicative, if the tense 
 84 
-NOTES TO PAGES 43, 44 
-of the main verb is historic (here hλ0). Notice that though the mood is altered, the tense remains the same; the original message was oi Τοῦρκοι καταφαίνονται. Cf. 7, 28 η.
+NOTES TO PAGES [REF] 
+of the main verb is historic (here hλ0). Notice that though the mood is altered, the tense remains the same; the original message was oi Τοῦρκοι καταφαίνονται. Cf. [REF] η.
 1. εἰ ἐλπίζοιεν whether they hoped; ἐλπίζοιεν in the original question was ἐλπίζουσι.
 2.  és rà μádiora in the highest degree. 13. εἶμεν 
 φοβοίμεθα .
@@ -638,7 +659,7 @@ What were these words in the original statement ?
 1.  Bovλóuevos if you are willing.
 2.  οὐκ ἴδιον ..the lead he had was not his own.
 ἔχοι.
-Cf. 5, 11 n.
+Cf. [REFn].
 1.  βουλεύσοιτο, he actually said βουλεύσομαι I'll think about it.
 2.  or sometimes introduces the original words, and is represented 
 in English by inverted commas.
@@ -649,12 +670,12 @@ name.
 : 
 The Turks subsequently advanced to Anatolicon, a small town situated in the lagoons, about five miles west of Messalonghi. The inhabitants had been accustomed to get their supplies of drinkingwater from the mainland, as there were no springs on the island of this the Turks were aware, and therefore expected to force it to surrender quickly. A Turkish shell, however, happened to fall on the Church of St. Michael, and, breaking through the pavement, disclosed a spring, which not only supplied sufficient water, but encouraged the people to think that a miracle had been performed on their behalf. After about a month the Turks abandoned the siege.
 PART IV.
-Section 37. ripâv, §§ 196, 197.
-Page 44, 2. Tapà yváμny contrary to expectation.
+Section 37. ripâv, §§ [REF].
+Page [REF]. Tapà yváμny contrary to expectation.
 1. ὅπερ 
 which no one would have believed, if he had been told, before it happened. av is used with the Past Tenses of the Indic. in 
 a Potential sense, expressing might have, would have, could have.
-Cf. 40, 18 n.
+Cf. [REFn].
 β. τὰ μέν 
 times.
 • 
@@ -662,14 +683,14 @@ Tà de partly.
 partly, or sometimes 
 • • • 
 at other 
-NOTES TO PAGES 44, 45 
+NOTES TO PAGES [REF] 
 85 
 1.  As an instance of Byron's energy, the following story may be quoted. When he was at Cephalonia, a number of workmen engaged in excavating were buried by the fall of a mass of earth. Byron heard of the accident while at dinner, and rushing to the place seized a spade and by his example stimulated the panic-stricken onlookers to set to work. The result was that all the workmen were rescued.
-2.  The Ionian islands, being under the protection of England, were the chief place of refuge for those Greeks who had been driven from their homes by the Turks. Cf. 34, 18 n.
+2.  The Ionian islands, being under the protection of England, were the chief place of refuge for those Greeks who had been driven from their homes by the Turks. Cf. [REFn].
 3.  âs av vaûs whatever ships they had. av, joined to Rel. pronouns or conjunctions, and followed by the Subjunctive, gives an Indefinite Sense, expressed in English by ever.
-Page 45, 7. On 30th December Byron and Count Gamba (an Italian) with their baggage and a large sum of money set sail in separate ships. Byron's ship fell in with a Turkish frigate, but succeeded in getting away to some rocky islands called Scrofes, where Byron concealed himself in a cave. Gamba and his ship were captured, but by a curious coincidence the captain of the Turkish frigate had once been saved from death by the Greek skipper, and, in gratitude for this, he pretended that he saw nothing suspicious about the vessel, and let it continue its voyage.
-Section 38. v, Xpĥodai, § 232. Contracted Futures, §§ 235, 1, 236, 237 (i.).
-1.  See Sections 34, 35.
+Page [REF]. On 30th December Byron and Count Gamba (an Italian) with their baggage and a large sum of money set sail in separate ships. Byron's ship fell in with a Turkish frigate, but succeeded in getting away to some rocky islands called Scrofes, where Byron concealed himself in a cave. Gamba and his ship were captured, but by a curious coincidence the captain of the Turkish frigate had once been saved from death by the Greek skipper, and, in gratitude for this, he pretended that he saw nothing suspicious about the vessel, and let it continue its voyage.
+Section 38. v, Xpĥodai, § 232. Contracted Futures, §§ [REF] (i.).
+1.  See Sections [REF].
 2.  οὔτε ὅθεν κομιοῦνται nor having whence they shall get rations, i.e., not being able to get rations.
 3.  čσTIV OTE sometimes. Cf. 1. 25. čσri in some places.
 4.  The disorder culminated in the following incident: A Souliote, noted for his bravery, came to the armoury with a young son of M. Botzares, and, having no written permission to enter, was stopped by the sentry. He persisted in going in, and the officer on guard ordered him to be arrested; a quarrel ensued, and the Souliote, having received a blow, killed the officer on the spot. In an instant alarm pervaded the town: the Souliotes rose to arms, threatening to storm the armoury and even Byron's house, if their countryman, who had been apprehended, was not set at liberty. The riot was at length appeased, but Byron declared that he would return to the Ionian islands if the Souliotes did not leave Messalonghi.—GORDON.
@@ -677,7 +698,7 @@ Section 38. v, Xpĥodai, § 232. Contracted Futures, §§ 235, 1, 236, 237 (i.).
 1.  ἔπρ 
 • 
 took steps to make the place secure. Verbs 
-of Effort take oπws with Fut. Indic. Cf. 23, 9 n.
+of Effort take oπws with Fut. Indic. Cf. [REFn].
 1.  oux egovo oros will not be able to. Cf. 1. 13 n.
 2.  eis is used emphatically with Superlatives, this man of all others, like Lat. unus.
 86 
@@ -685,22 +706,22 @@ NOTES TO PAGES 45-47
 1.  tŵv ka✪ ¿avróv of his contemporaries.
 On 9th April Byron went out to ride near the town and was overtaken by a heavy shower, and returned home in a boat. Shortly afterwards he complained of fever: the doctors prescribed bleeding, but he refused, saying, “I will drink all your medicines, but not one drop of my blood will I shed. All of it shall be shed on the field of battle." Delirium came on, then stupor, and at six o'clock in the afternoon of Easter Monday (19th April) at the instant of an awful thunderstorm Byron expired.
 His coffin was laid by the side of the grave of M. Botzares, but as he expressed a wish to be buried in the tomb of his ancestors (at Hucknall Torkard, near Nottingham), the body was removed to England, and his heart interred at Messalonghi.
-Section 39. dnλoûv, §§ 200, 201.
-Page 46, 10. τὰ ἑαυτῶν regarding only their own interests. 14. rois Xpημaoi from lack of money. Instrum. Dat.
-1.  oơa av δέŋ whatever was necessary. See 44, 22 n.
+Section 39. dnλoûv, §§ [REF].
+Page [REF]. τὰ ἑαυτῶν regarding only their own interests. 14. rois Xpημaoi from lack of money. Instrum. Dat.
+1.  oơa av δέŋ whatever was necessary. See [REFn].
 2.  A committee was formed in London, including Jeremy Bentham, Joseph Hume and T. Gordon (the historian of the war), and a loan amounting to £300,000 was raised. The security was very bad, and, in fact, the interest was never paid, but by a fortunate coincidence for Greek liberty, a mania for every kind of wild speculation had just then seized English capitalists.
 3.  A talent was a sum of money worth 6,000 drachmæ or £210 in English money. A drachma = a franc.
 4.  öσa λáßolev whatever money they got; after an historic tense (édarávwv), the Rel. followed by the Optat. is used in an Indefinite Sense. After a Primary tense, this would be ora âv λáßwσi. Cf. 1. 17.
-Page 47, 1. ek toû roloúrov, by such conduct.
+Page [REF]. ek toû roloúrov, by such conduct.
 "Every man of consideration in his own imagination wanted to place himself at the head of a band of armed men, and hundreds of civilians paraded the streets of Nauplia with trains of kilted followers, like Scottish chieftains. Phanariots and doctors of medicine, who in the month of April were clad in ragged coats, and who lived on scanty rations, threw off that patriotic chrysalis before summer was past, and emerged in all the splendour of brigand life, refulgent with brilliant but unused arms, fluttering about in rich Albanian habiliments, and followed by diminutive pipe-bearers and tall henchmen.FINLAY.
 Section 40. ioráva, Act. Voice, § 248.
 The Str. Aor., Perf., and 
 1. ἀντέστη αὐτῷ went against him. Plup. of iorával and its compounds are Intrans.
-NOTES TO PAGES 47, 48 
+NOTES TO PAGES [REF] 
 = 
 87 
 1. és áropíav karaσrĥoai = to reduce to helplessness (Wk. Aor.).
-ἐς ἀπορίαν καταστῆναι to be reduced to helplessness (Str. Aor.). 6. evpnrai Delib. Subj.; evporo might have been used. See 41, 7 n. "Mehemet-Ali was a determined reformer, although his reforms, like those of all Eastern despots, were directed solely to two pointsaugmenting his revenue, and forming a disciplined standing army. The first he brought about by a most horrible system of oppression and monopoly, turning the cultivators into bondsmen and making himself the only merchant and landowner in the country; the second he effected by establishing an arbitrary conscription among the Arab villagers, and purchasing the services of European instructors." GORDON.
+ἐς ἀπορίαν καταστῆναι to be reduced to helplessness (Str. Aor.). 6. evpnrai Delib. Subj.; evporo might have been used. See [REFn]. "Mehemet-Ali was a determined reformer, although his reforms, like those of all Eastern despots, were directed solely to two pointsaugmenting his revenue, and forming a disciplined standing army. The first he brought about by a most horrible system of oppression and monopoly, turning the cultivators into bondsmen and making himself the only merchant and landowner in the country; the second he effected by establishing an arbitrary conscription among the Arab villagers, and purchasing the services of European instructors." GORDON.
 1. τὰ τῆς χώρας . . . ἐς τὸ ἐπιτήδειον controlling the organisation of the country, he arranged matters to his own advantage.
 2. ὅδεv by which course.
 3.  ὅταν 
@@ -712,44 +733,44 @@ at any time when) I die, I shall be cremated.
 (ii.) It refers to an unknown number of occasions, e.g., whenever (= at every time when) I am hungry, I eat.
 ὅταν is used in sense (i.); ὁπόταν in sense (ii.); ἐπειδάν in either 
 sense.
-See 11. 16, 20.
+See 11. [REF].
 1.  éteidη úñéσrn since he had undertaken the expedition.
 2.  ὁπότε 
-Xooler whenever they came to close quarters; after an historic tense, őre, óñóre, and éradý, followed by the Optat. are used in the same Indefinite sense, as orav, órórav, and éπeiðáv, with the Subj. See 1. 13 n. Compare the use of the Relative, 46, 29 n.
-Page, 48, 1. δέov, Acc. Abs. See 16, 22 n.
+Xooler whenever they came to close quarters; after an historic tense, őre, óñóre, and éradý, followed by the Optat. are used in the same Indefinite sense, as orav, órórav, and éπeiðáv, with the Subj. See 1. 13 n. Compare the use of the Relative, [REFn].
+Page, [REF]. δέov, Acc. Abs. See [REFn].
 Section 41. iorával Mid. and Pass., § 249. Súvapai I am able, éniorapai I know, are conjugated like iorapai, but see § 256.
 1.  ἕως ἂν reipŵvrai until they should try; ews åv so long as or until, péxpi av (or μéxpi ov äv) until, followed by the Subj., have an Indefinite sense, not expressed in English. They refer :
 :
 (i.) to one occasion in the unknown future, e.g., we will work, till we have finished.
 (ii.) to an unknown period of time, e.g., while there is life, there is hope.
-After an historic tense, the same Indefinite sense is expressed by ews, μéxpi (or μéxpi ov), followed by the Optat. Compare 47, 13 n, 26 n.
+After an historic tense, the same Indefinite sense is expressed by ews, μéxpi (or μéxpi ov), followed by the Optat. Compare [REFn], 26 n.
 888 
 NOTES TO PAGES 48-50 
 1.  Tois éπixεiρhμaoi, Instrum. Dat. they were not successful in (lit. by) their efforts.
 2.  οὐκ ἔχοντες 
 not having a point at which they should make a stand, i.e., a rallying point.
-Page 49, 4. ews ȧvaykaσbeiev. See 48, 11 n.
+Page [REF]. ews ȧvaykaσbeiev. See [REFn].
 1.
 At four o'clock in the afternoon, a soldier, bearing a lighted match, was seen to leave the monastery and run towards the entrance of a great subterraneous magazine, situated outside-he fell, pierced with balls, and five of his companions, following his example, one after the other, shared his fate. Unable to execute their first project, the Greeks resolved to inflame the powder they had within the monastery. They ceased their fire, and the Turks darting on, sword in hand, scaled the walls on every side; when suddenly the Hellenic flag was lowered, a white banner, inscribed with the words 'Liberty or Death,' waved in the air, a single gun gave the signal, and a tremendous explosion, shaking the island and felt far out at sea, buried in the ruins of St. Nicholas thousands of the conquerors and the conquered!"-Gordon.
-Section 42. δεικνύναι, §§ 250, 251.
+Section 42. δεικνύναι, §§ [REF].
 1.  A desultory siege of Patras continued throughout the war.
 the management of the loan was not in accordance 
 1.  τὰ περί . with their views.
-2.  πρίν . Karaλvσelav until they should overthrow the existing democracy. The Greeks had elected representatives, but great confusion had arisen owing to party quarrels. If the main verb is negatived, and où æρív not before means not until, æpív takes the same construction as μéxp and ews, 48, 11 n. When рiv means before, it takes the Infin.
-Page 50, 2. οὐ πρότερον πρίν 
+2.  πρίν . Karaλvσelav until they should overthrow the existing democracy. The Greeks had elected representatives, but great confusion had arisen owing to party quarrels. If the main verb is negatived, and où æρív not before means not until, æpív takes the same construction as μéxp and ews, [REFn]. When рiv means before, it takes the Infin.
+Page [REF]. οὐ πρότερον πρίν 
 • • 
 not until; the Indic. is used referring to a Definite time, as is the case with all temporal conjunctions.
 1. διὰ τόν τε θάνατον 
 • 
-καὶ ὅτι (a) owing to his son's death, and (b) because the conspirators were unsuccessful. Cf. 14, 28 n.
+καὶ ὅτι (a) owing to his son's death, and (b) because the conspirators were unsuccessful. Cf. [REFn].
 1.  καθίστατο τοῖς ἐν τοῖς ἀγροῖς befel the rural population.
-2.  διὰ τὸ ποιεῖσθαι. Cf. 19, 20 η.
+2.  διὰ τὸ ποιεῖσθαι. Cf. [REF] η.
 It was owing to this Civil War that no assistance had been sent to Cassos and Psara.
 Section 43. iévai Indic. Mood, § 267.
 1.  Neocastron, situated on the mainland opposite the south end of Sphakteria, is generally known as Navarino, from some merchants who came from Navarre and settled there in the fifteenth century.
-NOTES TO PAGES 51, 52 
+NOTES TO PAGES [REF] 
 89 
-Page 51, 4. διὰ μáxns iévai to fight. Cf. διὰ þóßov eivai to be afraid, 36, 24.
+Page [REF]. διὰ μáxns iévai to fight. Cf. διὰ þóßov eivai to be afraid, [REF].
 diá in such phrases expresses the circumstances, lit. to come into a state of battle.
 1. Tolavrηs i.e., against disciplined troops.
 2.  Sphakteria is famous as the scene of the Spartan surrender in B.C. 425.
@@ -759,12 +780,12 @@ Section 44. lévai (all), § 267.
 1.  d' are is used with the Fut. Indic. to express on condition that. The Pres. Ind. of iéval (and its compounds) has a future meaning: the Past Imperfect and the other moods supply the missing forms of ἔρχομαι.
 OTOι av Boúλwvrau whithersoever they wished (lit. shall wish).
 • 
-Page 52, 5. ei èmíoiev if ever the enemy attacked; after an historic tense, ei with the Optat. expresses if ever. Cf. 47, 26 n. When the main verb is primary, the same meaning is expressed by v (= ei av), followed by the Subj. Cf. L. 8 and 47, 13 n.
+Page [REF]. ei èmíoiev if ever the enemy attacked; after an historic tense, ei with the Optat. expresses if ever. Cf. [REFn]. When the main verb is primary, the same meaning is expressed by v (= ei av), followed by the Subj. Cf. L. 8 and [REFn].
 1. Tapà λóyov contrary to expectation.
 · 
-1. τήν τε πόλιν they burnt (a) the town, and (b) whatever they could not carry away. See 14, 28 n.
-2.  v πws if perchance, i.e., in hopes that; after an historic tense, this might be el mos with Optat. Cf. 53, 12.
-3.  When Colokotrones was imprisoned (see 50, 11), he exclaimed, "I have twice saved my country, and shall be called upon to save it a third time".-GORDON.
+1. τήν τε πόλιν they burnt (a) the town, and (b) whatever they could not carry away. See [REFn].
+2.  v πws if perchance, i.e., in hopes that; after an historic tense, this might be el mos with Optat. Cf. [REF].
+3.  When Colokotrones was imprisoned (see [REF]), he exclaimed, "I have twice saved my country, and shall be called upon to save it a third time".-GORDON.
 4.  The Greeks were so demoralised that Colokotrones had great difficulty in keeping his men together. On one occasion his scouts rushed in crying, "Back, back, there are horsemen in the olive-yard". Presently, however, the horsemen were transformed into a flock of crows and flew away.-TRICOUPI.
 5.  During this expedition Ibrahim advanced nearly as far as Argos.
 90 
@@ -773,46 +794,46 @@ From a lofty point in the road he caught a view of Hydra, and, stretching out hi
 Section 45. didóvaı, Act. Voice, § 262.
 1.  When the Turks retired from Messalonghi (Section 36), they buried their guns, and erected tombstones over them: the Greeks were deceived by this stratagem, and proudly pointed to the inscriptions which recorded the fate of their enemies. When Kiutayhé (or Reschid Pasha, as he was generally called) began the second siege, he dug up the guns and used them against the Greeks.
 2.  εἰ μή except.
-Page 53, 2. ei.
+Page [REF]. ei.
 • 
 éyévero if this had not been done, they would have been compelled. Unfulfilled Past Condition.
-1. ÓTÓTE. Cf. 47, 26 n.
-2.  εἴ πως. Cf. 52, 11 n.
+1. ÓTÓTE. Cf. [REFn].
+2.  εἴ πως. Cf. [REFn].
 • 
 ἄνευ Toλioρkías, lit. without expense and a siege, i.e., without a costly siege.
 1.  λίθους τε .
 καὶ εἴ τι 
-Cf. 52, 9 n.
-1.  dúvaσbai ǎv would be able; this could have been expressed őri δύναιτο ἄν. Cf. 40, 18 n.
+Cf. [REFn].
+1.  dúvaσbai ǎv would be able; this could have been expressed őri δύναιτο ἄν. Cf. [REFn].
 • 
 1.  οὐδεμίαν avrov they had no hope that (is) they would prevail, unless they were to get possession of it.
 2.  Tò èpyov, i.e., the making of the mound; poσéxovor is Dat. Plur. of Partic.
 Section 46. didóva, Mid. and Pass., § 263.
 1.  καλῶς ἔπραξαν.
-Cf. 31, 21 n.
-Page 54, 2. čws äv. Cf. 48, 11 n.
+Cf. [REFn].
+Page [REF]. čws äv. Cf. [REFn].
 1.  καθ' ἡμέραν 
 προϊούσαν as each day came on.
-1.  ἀσθενέστεροι ἢ ὥστε too weak to. Cf. 31, 5 n.
+1.  ἀσθενέστεροι ἢ ὥστε too weak to. Cf. [REFn].
 2.  "At Messalonghi, when they issued forth amid the drizzle of the night, feeling their desolation and their doom, they said to one another, 'The Almighty Himself weeps for us to-night!' But they went on, sword in hand, to fall for their country, greeting her with the gladsome cry, 'Arise, thou dearest mother!""GENNADIUS.
 3.  κραυγῇ . by some cry of confusion (lit. of those confused). "Almost at the moment when the garrison rushed on the Turks, that portion of the Messalonghiots which was then on the bridges raised a cry of 'Back, back'. Great part of the Messalonghiots stopt, fell back, and returned into the town with the military escort, which ought to have formed the rear-guard of the sortie. The origin of this ill-timed cry, which weakened the force of the sortie and added to the victims in the place, has excited much unnecessary speculation. It 
 NOTES TO PAGES 54-57 
 91 
 evidently arose among those who were in danger of being forced into the ditch. Their cry was repeated so loudly that it created a panic." FINLAY.
-Page 55, 4. ὅσοις ἐντύχοιεν. Cf. 46, 29 n.
-1.  εἴ πως. Cf. 53, 12.
-2.  âv éyévero. Cf. 53, 2 n. The deserter was a Bulgarian mer
+Page [REF]. ὅσοις ἐντύχοιεν. Cf. [REFn].
+1.  εἴ πως. Cf. [REF].
+2.  âv éyévero. Cf. [REFn]. The deserter was a Bulgarian mer
 cenary.
-Section 47. Str. Aor., ἔβην, ἔγνων, ἑάλων, ἔδυν, §§ 271, 272.
-1.  où πpoσĥkov, Acc. Abs. See 16, 22 n. 25. Bore on condition that.
+Section 47. Str. Aor., ἔβην, ἔγνων, ἑάλων, ἔδυν, §§ [REF].
+1.  où πpoσĥkov, Acc. Abs. See [REFn]. 25. Bore on condition that.
 2.  τοὺς δὲ μὴ δεχομένους.
 (saying) that they would compel those 
-who rejected the terms to observe them. 29. ǎopevo gladly. Cf. 42, 28 n. Page 56, 11. ổơa .
+who rejected the terms to observe them. 29. ǎopevo gladly. Cf. [REFn]. Page [REF]. ổơa .
 Section 48.
-idolev. See 46, 29 n.
+idolev. See [REFn].
 1.  The English admiral, Sir Edward Codrington, was in command of the whole fleet, as being the senior admiral. The instructions which he gave to his colleagues in the event of a general engagement concluded with Nelson's words, that no captain could do very wrong who placed his ship alongside that of an enemy.—FYFFE.
-2.  οὐ πολὺς χρόνος. Cf. 37, 21 n.
-Page 57, 1. v it was possible. Cf. 1. 8.
+2.  οὐ πολὺς χρόνος. Cf. [REFn].
+Page [REF]. v it was possible. Cf. 1. 8.
 1. rà vaváyia, some of these wrecks are still to be seen on shore and beneath the water.
 2.  ἐμοί 
 • 

--- a/drafts/chambers_notes_ocr.md
+++ b/drafts/chambers_notes_ocr.md
@@ -337,504 +337,495 @@ Pass. and Mid. Pres. of λύειν, Ind. λύομαι, Inf. λύεσθαι, P
 
 Pass. and Mid. Pres. of ποιεῖν, Ind. ποιοῦμαι, Inf. ποιεῖσθαι, Part. ποιούμενος, [REFs]; ὄνομα, [REFs]; γένος, [REFs].
 
-1. οἱ ἐκ τῆς περιοικίδος Έλληνες.-Introd. Note B. (iv.).
-2. πεῖραν ποιοῦνται τοῦ τείχους make an attempt on the fort.
-3.  áμúver means to ward off, sc. Tous Toλeμious, the Mid. means to ward off for oneself, hence to defend oneself. Cf. [REFn].
-4.  βουλευομένοις πρὸς deliberating with regard to.
-5.  ὥστε . ¿¿eλÕéîv on condition that the Turks should march out. Cf. [REFn].
-72 
-1.  ἐπὶ τούτῳ 
-NOTES TO PAGES [REF] 
-on this condition they guarantee their lives. 22. ὡς ἀδύνατον ν since it was impossible in any other way. The Acc. is used absolutely (instead of the Gen.) with Impersonal verbs, or Neut. adj. with ov, see 1. 29 eυ πapaoxov there being a favourable opportunity, from Impersonal ev mapéxe there is a favourable opportunity. às is often used with Partic. or Prepositional phrases, to give the motive for the action expressed by the main verb. Cf. [REF].
-1.  vipxe their numbers were not sufficient. Cf. [REFn].
-2.  See 1. 22 n.
-· 
-1.  Καλαμάταν . ἐπολιόρκουν lit. they besieged a place (χωρίον τι) Kalamata, as to its name. Καλαμάταν is in apposition to χωρίον, ὄνομά is Acc. of Respect.
-Page [REF]. σπονδὰς ποιοῦνται 
-= 
-σπένδονται. This periphrasis with 
-= 
-ποιεῖσθαι is extremely common; cf. 1. 7 εὐχὰς ποιοῦνται εὔχονται; 1. 29 λείαν ἐποιοῦντο = ελῄζοντο ; 1. 30 φυγὴν ἐποιοῦντο = ἔφευγον, and other instances in Vocab. 8.v. Toleiv. The Passive is formed by yiyveobai, e.g., ἀρχὴν ποιοῦνται τοῦ πολέμου they begin the war, ἀρχὴ τοῦ πολέμου yiyverai the war is begun. Cf. [REF].
-1. BOTE. See [REFn].
-2. Tŷ Túxn by their good fortune. Instrum. Dat.
-"On the 5th of April, 1821, the Greeks sang their first thanks to God for victory. The ceremony was performed on the banks of the torrent that flows by Kalamata. Twenty-four priests officiated and five thousand armed men stood round. Never was a solemn service of the Orthodox Church celebrated with greater fervour, never did hearts overflow with sincerer devotion to Heaven, nor with warmer gratitude to their church and their God. Patriotic tears poured down the cheeks of rude warriors, and ruthless brigands sobbed like children. All present felt that the event formed an era in the history of their nation."-FINLAY.
-1. às airíovs õvras as being the authors.
-2.  Kará in accordance with.
-3.  ὅτι . . . σελήνη in apposition to λόγος. We might omit ὅτι and put inverted commas.
-Section 15. Pass. and Mid. Ind. Past Imperf. of λvew, éλvóμny, § 183; of ποιεῖν, ἐποιούμην, § 199; Str. Aor. Mid. of γίγνεσθαι, Ind. ἐγενόμην, Inf. γενέσθαι, Part. γενόμενος.
-1.  τῶν 
-• 
-yevouévov of what had happened; the commonest Str. Aor. Mid. are ᾐσθόμην (αἰσθάνομαι perceive), ἀφικόμην (ἀφικνούμαι arrive), ἐπυθόμην (πυνθάνομαι ascertain), έτραπόμην (τρέπομαι turn), ὑπεσχόμην (ὑπισχνούμαι promise).
-1.  Many of these Mussulmans were Greeks by origin; their fore
-NOTES TO PAGES 17-19 
-73 
-fathers had adopted the religion of Mahomet to avoid having to send their children as tribute to Constantinople.
-1.  λeíav éπoloûvтo they plundered. Cf. [REFn].
-Page [REF]. où διὰ μakpov (sc. xpóvov) lit. not at a great interval of time, i.e., soon.
-1. ἔχοντες 
-· 
-.. having the events at Kalamata as examples of all that they too were likely to suffer.
-1. The Greeks at Patras issued a proclamation containing merely these emphatic words,-Peace to the Christians! Respect to the Consuls! Death to the Turks! 
-Lord Byron has translated one of their battle-songs, "Sons of the Greeks, arise!" 
-Section 16. Act. Fut. of Xue, Ind. λvow, Inf. Xvoew, Part. Xvowv, § 181. πόλις, § 37. ευγενής, § 100. ἐκεῖνος, -η, -ο, § 142.
-1.  κai čтi πрóтepov or a little before; xaí corrects the previous statement.
-2.  TOUS Tрокpírovs the Primates; these were Greek officials, appointed by the Turks to act as local magistrates in unimportant cases, and to collect the taxes.
-3.  δι' ὧν . . . ἐπράσσοντο by whose agency they raised the taxes. 16. ås BovλevσovTes to deliberate; the Fut. Partic. expresses purpose as in Latin.
-• 
-• • 
-ἐν ἀξιώματι ἦσαν ὑπό were held in honour by. Cf. [REF]. 18. no@ávovтo... lit. perceived the Greeks that they were preparing, i.e., perceived that the Greeks were preparing.
-1.  ἐσκόπουν ὅπως . . . κωλύσουσι considered how they should prevent. Ind. Question; the tense and mood of the original question "How shall we prevent?" are retained, just as is the case with ori. Cf. [REFn].
-Anvel, Instrum. Dat., by the taking.
-1.  οὐ προυχώρει 
-• 
-matters did not proceed as they wished. 28. ἄριστα ἕξει τὰ πράγματα matters would be best; ἄριστα is an adverb. Cf. [REFn].
-1.  For omission of conjunction see Introd. Note A. (ii.).
-Page [REF]. Ek πapaσкevĤs by arrangement.
-1. προσεποιοῦντο 
-they pretended (a) that a letter had come ..., 
-and (b) that he advised them.
-• 
-For the two different constructions 
-(i.) Acc. and Inf. (ii.) or clause, see [REFn].
-1. μελλόντων 
-• 
-since the government intended to kill them all.
-oi év ápxaîs = ai ȧpxaí, [REF].
-1.  ἐπ ̓ οἴκου means in the direction of home, homewards 1. 1 ἐπὶ τῆς πόλεως: ἐπ ̓ οἶκον 1. 6 means home, implying that you get there. Cf. [REFn].
-74 
-NOTES TO PAGES 19-21 
-Section 17. Act. Weak Aor. of λveiv, Ind. ëλvoa, Inf. Xvoai, Part. λύσας, § 182. βασιλεύς, § 37. μέγας, § 105.
-1.  διὰ τὸ . . . ἔχειν owing to his regarding all alike with suspicion. The Article with the Infin. forms a noun-equivalent. It can be used in any case (Dat. 1. 26; Nom. [REF]) and is especially common after prepositions. The Infin. may have a subject, or object (as rávτas), and may be qualified by any adverbs (as ouoíws) or adverb-equivalents (as év vπovía), just as is the case with any other use of the Infin.
-2.  μéya тi πрâyμa πpáşavra lit. having done some great deed, i.e., by some violent measure.
-3.  τῷ Evλλaßeiv by arresting them. Cf. 1. 20 n.
-• 
-1.  The Chief Dragoman and Secretary were important Turkish officials.
-Page [REF]. rò μǹ vñakovew lit. the not-obeying, i.e., disobedience. See [REFn].
-1. βασιλέως 
-= 
-Σουλτάνου.
-1.  ròv yàp Baoiλéa, Or. Obl. Cf. [REF].
-2.  διὰ To Tηv éoprǹv äyeɩ because of their keeping the festival. See [REFn]. Gregory was arrested on Easter Eve.
-3.  čruxov ronoovres happened to be going to celebrate. Cf. [REF]. 19. Sultan Mahmud II. was called "the Butcher" by the Greeks after this murder. Gregory was 82 years old at the time of his execution. There is no reason to suppose that he was inculpated in the conspiracy. At all events he had solemnly excommunicated Hypsilantes when the news of the insurrection in Roumania reached Constantinople.
-Section 18. γλυκύς, § 102. πολύς, § 105.
-1.  The feelings with which the Jews and Greeks regarded one another may be illustrated by this extract from Gordon: "A band of Jews attended the Pasha's camp voluntarily in the capacity of executioners, allured merely by the pleasure of butchering with clubs the Greek prisoners. One of these execrable savages afterwards boasted that in a single day he had with his own hands slaughtered sixty-four victims.
-"" 
-Page [REF]. Greek priests wear beards, while other Greeks do not, hence it was easy to recognise the body.
-1. ὥσπερ θείᾳ τύχῃ providentially. 13. οὐ χαλεπόν 
-suffered.
-it is not hard to imagine all that the Greeks 
-Section 19. Act. Perf. of Xúew, Ind. λevka, Plup. λeλúкn, Inf. λeλvkévaι, Part. λeλvkós, § 182. Some Perfects end in Oa, ya, da, e.g., ἐλήλυθα (ἔρχομαι come), πέφευγα (φεύγω fee), εἴληφα (λαμβάνω take).
-1.  καταλαμβάνουσι 
-· 
-peλovra find that the people were on the 
-NOTES TO PAGES 21-23 
-75 
-point of holding an assembly. Verbs of finding and sense-perception (perceiving, seeing, knowing) take the Participle instead of the Infinitive. Cf. [REFn].
-1.  is Telow to persuade. Cf. [REFn].
-2.  Teixiopara. The fortresses in the Peloponnese still held by the Turks were Nauplia, Navarino, Modon, Coron, Monemvasia, Patras and Tripolitza.
-Page [REF]. τοὺς νησιώτας καὶ ὅσοι 
-eioiv. Cf. [REFn]. 7. ἀπ' αὐτῶν = ἀπὸ τῶν κινδύνων which will result there from. 8. ὅσα . ἡμαρτήκασι the crimes of the Turks; so ὅσα πεπόνθαμεν 
-our sufferings.
-1.  πάντων ὧν ἐπεπόνθεσαν for all they had suffered. ὧν is attracted into the case of its Antecedent návrov; this attraction occurs when the Relative Pron. would naturally be in the Acc. and its Antecedent is in the Gen. or Dat.
-21 n.
-1.  ἠσθάνοντο 
-ὄντας. Cf. 21, 
-Section 20. Fut. Mid. of Xve, Ind. Xvooμai, Inf. λvoeσbai, Part. λυσόμενος, § 183; of είναι, Ind. ἔσομαι, Inf. ἔσεσθαι, Part. ἐσόμενος, § 266. vaus § 49 (14); voûs § 26.
+1. οἱ ἐκ τῆς περιοικίδος Ἕλληνες. Introd. Note B. (iv.).
+2. πεῖραν ποιοῦνται τοῦ τείχους *make an attempt on the fort*.
+3. ἀμύνειν means to *ward off*, sc. τοὺς πολεμίους, the Mid. means *to ward off for oneself*, hence *to defend oneself*. Cf. [REFn].
+4. βουλευομένοις πρὸς *deliberating with regard to*.
+5. ὥστε... ἐξελθεῖν *on condition that the Turks should march out*. Cf. [REFn].
+6. ἐπὶ τούτῳ... *on this condition they guarantee their lives*.
+7. ὡς ἀδύνατον ὄν... *since it was impossible in any other way*. The Acc. is used absolutely (instead of the Gen.) with Impersonal verbs, or Neut. adj. with ὄν, see [REF] εὖ παρασχόν *there being a favourable opportunity*, from Impersonal δὖ παρέχει *there is a favourable opportunity*. ὡς is often used with Partic. or Prepositional phrases, to give the motive for the action expressed by the main verb. Cf. [REF].
+8. ὑπρχε *their numbers were not sufficient*. Cf. [REFn].
+9.  See [REFn].
+10. Καλαμάταν... ἐπολιόρκουν lit. *they besieged a place* (χωρίον τι) *Kalamata, as to its name*. Καλαμάταν is in apposition to χωρίον, ὄνομά is Acc. of Respect.
+11. σπονδὰς ποιοῦνται = σπένδονται. This periphrasis with ποιεῖσθαι is extremely common; cf. [REF] εὐχὰς ποιοῦνται = εὔχονται; [REF] λείαν ἐποιοῦντο = ελῄζοντο; [REF] φυγὴν ἐποιοῦντο = ἔφευγον, and other instances in Vocab. s.u. ποεῖν. The Passive is formed by γίγνεσθαι, e.g., ἀρχὴν ποιοῦνται τοῦ πολέμου *they begin the war*, ἀρχὴ τοῦ πολέμου γίγνεται *the war is begun*. Cf. [REF].
+12. ὥστε. See [REFn].
+13. τῇ τύχῃ *by their good fortune*. Instrum. Dat.
+14. "On the 5th of April, 1821, the Greeks sang their first thanks to God for victory. The ceremony was performed on the banks of the torrent that flows by Kalamata. Twenty-four priests officiated and five thousand armed men stood round. Never was a solemn service of the Orthodox Church celebrated with greater fervour, never did hearts overflow with sincerer devotion to Heaven, nor with warmer gratitude to their church and their God. Patriotic tears poured down the cheeks of rude warriors, and ruthless brigands sobbed like children. All present felt that the event formed an era in the history of their nation." -FINLAY.
+15. ὡς αἰτίους ὄντας *as being the authors*.
+16. κατά *in accordance with*.
+17. ὅτι... σελήνη in apposition to λόγος. We might omit ὅτι and put inverted commas.
+
+
+### Section 15. 
+
+Pass. and Mid. Ind. Past Imperf. of λύειν, ἐλυόμην, [REFs]; of ποιεῖν, ἐποιούμην, [REFs]; Str. Aor. Mid. of γίγνεσθαι, Ind. ἐγενόμην, Inf. γενέσθαι, Part. γενόμενος.
+
+1. τῶν... γενομένων *of what had happened*; the commonest Str. Aor. Mid. are ᾐσθόμην (αἰσθάνομαι *perceive*), ἀφικόμην (ἀφικνούμαι *arrive*), ἐπυθόμην (πυνθάνομαι *ascertain*), έτραπόμην (τρέπομαι *turn*), ὑπεσχόμην (ὑπισχνούμαι *promise*).
+2. Many of these Mussulmans were Greeks by origin; their forefathers had adopted the religion of Mahomet to avoid having to send their children as tribute to Constantinople.
+3. λείαν ἐποιοῦντο *they plundered*. Cf. [REFn].
+4. οὐ διὰ μακροῦ (sc. χρόνου) lit. *not at a great interval of time*, i.e., *soon*.
+5. ἔχοντες... *having the events at Kalamata as examples of all that they too were likely to suffer*.
+6. The Greeks at Patras issued a proclamation containing merely these emphatic words: Peace to the Christians! Respect to the Consuls! Death to the Turks!
+7. Lord Byron has translated one of their battle-songs, "Sons of the Greeks, arise!"
+
+
+### Section 16.
+
+Act. Fut. of λύειν, Ind. λύσω, Inf. λύσειν, Part. λύσων, [REFs]. πόλις, [REFs]. ευγενής, [REFs]. ἐκεῖνος, -η, -ο, [REFs].
+
+1. καὶ ἔτι πρότερον *or a little before*; καί corrects the previous statement.
+2. τοὺς προκρίτους *the Primates*; these were Greek officials, appointed by the Turks to act as local magistrates in unimportant cases, and to collect the taxes.
+3. δι' ὧν... ἐπράσσοντο *by whose agency they raised the taxes*.
+4. ὡς βουλεύσοντες *to deliberate*; the Fut. Partic. expresses purpose as in Latin.
+5. ἐν ἀξιώματι ἦσαν ὑπό... *were held in honour by....* Cf. [REF]
+6. ᾐσθάνοντο... lit. *perceived the Greeks that they were preparing*, i.e., *perceived that the Greeks were preparing*.
+7. ἐσκόπουν ὅπως... κωλύσουσι *considered how they should prevent*. Ind. Question; the tense and mood of the original question "How shall we prevent?" are retained, just as is the case with ὅτι. Cf. [REFn].
+8. λήψει, Instrum. Dat., *by the taking*.
+9. οὐ προυχώρει... *matters did not proceed as they wished*.
+10. ἄριστα ἕξει τὰ πράγματα *matters would be best*; ἄριστα is an adverb. Cf. [REFn].
+11. For omission of conjunction see Introd. Note A. (ii.).
+12. ἐκ παρασκευῆς *by arrangement*.
+13. προσεποιοῦντο... *they pretended (a) that a letter had come ..., and (b) that he advised them*. For the two different constructions (i.) Acc. and Inf. (ii.) ὅτι clause, see [REFn].
+14. μελλόντων... *since the government intended to kill them all*. οἱ ἐν ἀρχαῖς = αἱ ἀρχαί, [REF].
+15. ἐπ' οἴκου means *in the direction of home*, *homewards* [REF] ἐπὶ τῆς πόλεως: ἐπ̓ οἶκον [REF] means *home*, implying that you get there. Cf. [REFn].
+
+
+### Section 17. 
+
+Act. Weak Aor. of λύειν, Ind. ἔλυσα, Inf. λῦσαι, Part. λύσας, [REFs]. βασιλεύς, [REFs]. μέγας, [REFs].
+
+1. διὰ τὸ... ἔχειν *owing to his regarding all alike with suspicion*. The Article with the Infin. forms a noun-equivalent. It can be used in any case (Dat. [REF]; Nom. [REF]) and is especially common after prepositions. The Infin. may have a subject, or object (as πάντας), and may be qualified by any adverbs (as ὁμοίως) or adverb-equivalents (as ἐν ὑποψίᾳ), just as is the case with any other use of the Infin.
+2. μέγα τι πρᾶγμα πράξαντα lit. *having done some great deed*, i.e., *by some violent measure*.
+3. τῷ... ξυλλαβεῖν *by arresting them*. Cf. [REFn].
+4. The Chief Dragoman and Secretary were important Turkish officials.
+5. τὸ μὴ ὑπακούειν lit. *the not-obeying*, i.e., *disobedience*. See [REFn].
+6. βασιλέως = Σουλτάνου.
+7. τὸν γὰρ βασιλέα, Or. Obl. Cf. [REF].
+8. διὰ τὸ τὴν ἑορτήν ἄγειν *because of their keeping the festival*. See [REFn]. Gregory was arrested on Easter Eve.
+9. ἔτυχον ποιήσοντες *happened to be going to celebrate*. Cf. [REF].
+10. Sultan Mahmud II. was called "the Butcher" by the Greeks after this murder. Gregory was 82 years old at the time of his execution. There is no reason to suppose that he was inculpated in the conspiracy. At all events he had solemnly excommunicated Hypsilantes when the news of the insurrection in Roumania reached Constantinople.
+
+
+### Section 18.
+
+γλυκύς, [REFs]. πολύς, [REFs].
+
+1. The feelings with which the Jews and Greeks regarded one another may be illustrated by this extract from Gordon: "A band of Jews attended the Pasha's camp voluntarily in the capacity of executioners, allured merely by the pleasure of butchering with clubs the Greek prisoners. One of these execrable savages afterwards boasted that in a single day he had with his own hands slaughtered sixty-four victims."
+2. Greek priests wear beards, while other Greeks do not, hence it was easy to recognise the body.
+3. ὥσπερ θείᾳ τύχῃ *providentially*.
+4. οὐ χαλεπόν... *it is not hard to imagine all that the Greeks suffered.*
+
+
+### Section 19.
+
+Act. Perf. of λύειν, Ind. λέλυκα, Plup. ἐλελύκη, Inf. λελυκέναι, Part. λελυκώς, [REFs]. Some Perfects end in θα, γα, φα, e.g., ἐλήλυθα (ἔρχομαι *come*), πέφευγα (φεύγω *flee*), εἴληφα (λαμβάνω *take*).
+
+1. καταλαμβάνουσι μέλλοντα *find that the people were on the point of holding an assembly*. Verbs of finding and sense-perception (perceiving, seeing, knowing) take the Participle instead of the Infinitive. Cf. [REFn].
+2. ὡς πείσων to persuade. Cf. [REFn].
+3. τειχέσματα. The fortresses in the Peloponnese still held by the Turks were Nauplia, Navarino, Modon, Coron, Monemvasia, Patras and Tripolitza.
+4. τοὺς νησιώτας καὶ ὅσοι... εἰσίν. Cf. [REFn].
+5. ἀπ' αὐτῶν = ἀπὸ τῶν κινδύνων *which will result therefrom*.
+6. ὅσα... ἡμαρτήκασι *the crimes of the Turks*; so ὅσα πεπόνθαμεν *our sufferings*.
+7. πάντων ὧν ἐπεπόνθεσαν *for all they had suffered*. ὧν is attracted into the case of its Antecedent πάντων; this attraction occurs when the Relative Pron. would naturally be in the Acc. and its Antecedent is in the Gen. or Dat.
+8. ᾐσθάνοντο... ὄντας. Cf. [REFn].
+
+
+### Section 20.
+
+Fut. Mid. of λύειν, Ind. λύσομαι, Inf. λύσεσθαι, Part. λυσόμενος, [REFs]; of εἶναι, Ind. ἔσομαι, Inf. ἔσεσθαι, Part. ἐσόμενος, [REFs]. ναῦς [REFs]; νοῦς [REFs].
+
 1.  The inhabitants of Psara, Spetza, and Hydra supplied sailors to man the Sultan's fleet, as well as paying a small tribute.
-2.  τὰ δὲ ἄλλα . . in other respects they were free citizens.
-3.  During the wars which followed the French Revolution, the crews often doubled their capital by carrying grain from the Bosphorus to the blockaded towns.
-Page [REF]. dógav Acc. Abs. from Impersonal dokeî it seems good :— since they had determined. Cf. [REFn].
-• 
-• 
-• 
-1. ὅπως ξυλλήψονται to arrest. 9. ἐπιμελησόμενοι ὅπως βοήθειαν to arrange to prevent the Sultan sending help. Verbs of effort, e.g., erueλéîodai, πpáσσeV ἐπιμελεῖσθαι, πράσσειν take pains, pulárσeolau take precautions, take ones with Fut. Ind. ἐπιμελησόμενοι is in the Nom. by sense-construction, ἄριστον εφαίνετο 
-Tλeiv being equivalent to they determined to sail.
-1.  ἐφαίνοντο παρασκευαζόμενοι were clearly making ready; φαίνομαι εἶναι I appear to be ; φαίνομαι ὢν I clearly am.
-Section 21. Weak Aor. Mid. of Ave, Ind. Avσáμny, Inf. λvoaodai, Part. Avoάuevos, § 183.
-χείρ § 49 (24). ἀργυρους, § 93.
-1.  The Turkish guns had a longer range than those of the Greeks, which made the latter unwilling to approach the man-of-war. On the other hand the Turkish gunners were so erratic that Lord Byron 
-76 
-NOTES TO PAGES 23-26 
-remarked on one occasion that they would be more formidable if they did not take aim.
-1.  γνώμην ἐποιήσατο proposed.
-Page [REF]. éyéμoav kλŋparidwv they filled with brushwood. 10. és rò... getting into the small boat they rowed away.
-1.  où yàp hv for it was not possible.
-• 
-1.  διὰ τὸ πpoσéxew owing to the enemy paying attention. Cf. [REFn]. On several other occasions Canaris repeated the exploit here described.
-2.  The Greeks excused these murders on the ground that they were avenging Gregory's execution.
-Section 22. Pass. Weak Aor. of λvew, Ind. ‹λúðŋy, Inf. λvôĥvai, Part. λυθείς, §§ [REF] (3); Fut. Ind. λυθήσομαι, Ιnf. λυθήσεσθαι, Part. λυθησόμενος, § 183.
-1.  TOUTWV.-Introd. Note A. (ii.).
-2.  Demetrius Hypsilantes is thus described by Gordon: "Nature had favoured him more in mind than in his corporeal frame, for his diminutive stature, bald head, awkward carriage, and indistinct utterance, were ill-calculated to win the opinions of those who beheld him. On the other hand it was difficult to know without esteeming him, for even his enemies were forced to confess, that to ardent patriotism he united courage, integrity and humanity, disregarded the allurements of pleasure, and had much goodness of heart, with a steadiness of purpose which at times bordered upon obstinacy." 
-"Colokotrones, like his father, had been a clepht. Tall and athletic, with a profusion of black hair and expressive features, alternately lighted up with boisterous gaiety, or darkened by bursts of passion : among the soldiers he seemed born to command, having just the manners and bearing calculated to gain their confidence." 
-Page [REF]. v. Cf. [REFn].
-1.  τῶν παρόδων 
-ἐσκομισθήσεται to keep watch on the passes to prevent supplies being sent in. Cf. [REFn].
-1.  The camp was situated at Valtetzi, several miles south of Tripolitza.
-2.  The moral effect of this victory in encouraging the Greeks was out of all proportion to the losses actually inflicted on the Turks, which amounted to about 400 men.
-Section 23. ȧvýp, § 49 (1); yvvý, § 49 (5).
-Page [REF]. hy it was possible. Cf. [REF].
-• 
-1.  εἴ τινες · if any were known to them, i.e., they sent to any of those inside whom they knew, 
-NOTES TO PAGES [REF] 
-77 
-1.  ἐπὶ τῷ [REFn].
-• 
-δέxeobai on condition of receiving. Cf. [REFn]; 
-1.  The report that a Turkish army was coming turned out to be false.
-Section 24. Pass. and Mid. Perf. Ind. of Xúeiv, δέλvpai, Plup. ἐλελύμην, Ιnf. λελύσθαι, Part, λελυμένος, § 183.
-Page [REF]. év TO NEOKáσTрo. Navarino had capitulated on 19th Aug. and a dispute arose about searching the Turkish women for jewels which they were supposed to have concealed. "Women wounded with musket balls and sabre cuts rushed to the sea seeking to escape and were deliberately shot. Greeks seized infants from their mothers' breasts and dashed them against the rocks. Children, three and four years old, were hurled living into the sea and left to drown. When the massacre was ended, the dead bodies washed ashore or piled on the beach threatened to cause a pestilence. Phrantzes (a Greek priest) who records these atrocities of his countrymen with shame and indignation, himself hired men to burn the bodies of the victims with the wrecks of some vessels in the harbour."-FINLAY.
-1.  Colokotrones records in his Memoirs that when he rode into the town his horse "from the walls to the palace never touched the earth,” owing to the accumulation of dead bodies.
-2.  τοὺς ἔνδον ἀποκτείνοντες ἐπέπαυντο, lit. murdering the inhabitants they had then desisted.
-3.  εἴ τι παρελέλειπτο 
-they plundered all that had been left. Some of the richest families in Greece to-day owe the foundation of their fortunes to the spoil of Tripolitza.
-1.  "After the Greeks had been in possession of the city for fortyeight hours, they deliberately collected together about 2,000 persons of every age and sex, but principally women and children, and led them to a ravine in the nearest mountain, where they murdered every soul. . . Some prisoners were spared for a short time to bury the bodies of their slaughtered countrymen, which were putrefying by thousands in almost every house and garden. Even this precaution was too long neglected. The air was already tainted with a deadly miasma and a terrible epidemic soon broke out among the Greeks."-FINLAY.
-78 
-NOTES TO PAGES [REF] 
-PART III.
-Section 25. Act. Subj. Pres. of eivai, &, § 266; of λúeiv, dúw, § 181 ; Wk. Aor., λύσω, § 182; Str. Aor. of πάσχειν, πάθω ; Pres. of ποιεῖν, ποιῶ, § 198.
-Regular Compar. of Adj., §§ [REF] and Adverbs, § 173.
-Page [REF]. áμа тô hρi áрxoμένe with the beginning of the spring (see cap). The Partic. is used as in Latin ante urbem conditam: Oépos summer includes spring and autumn, and is used of the whole period during which military operations were carried on in ancient times.
-· 
-· 
-1. ὅπως ἐσαγάγωσιν in order to introduce; όπως (or iva) in order that with the Subj. expresses purpose. The Aor. in the Subj. Optat. and Imperat. moods is not a past tense: the difference between it and the present is not a difference in time but in kind of action ; the present regards the action as continuing, the Aorist regards it simply as occurring. Cf. [REF].
-2. Twν výσwν Kрarnbeir@v, Gen. Abs. expressing a condition, if the islands were conquered.
-3. ἐπικινδυνοτάτην εἶχον. See [REF] κ.
-4.  εὐτυχήσαντες. See Sect. 21.
-5.  avrov than they were. The Gen. of Comparison is used like the Latin Abl. of Comparison; it is a Gen. of Separation, laxuρÓTEρOL aurav meaning stronger starting from them.
-6.  Tois nãσi Evrорwтárny excellently provided with everything. "Celebrated for its fertility and the enchanting aspect of its gardens, Chios carried on a brisk trade in silk and fruit; from thence Constantinople was supplied with oranges, lemons and citrons; but the most valuable production of the country is gum mastic, a substance highly valued by Eastern ladies, who amuse their indolence by chewing it, deriving from that practice as much gratification as their male relations enjoy by inhaling the fumes of tobacco."-GORDON.
-7.  poßoúμevo un пábwσi fearing that they would suffer. The object clauses after words of fearing are introduced by μn lest, followed by the subj.
-8.  Antonius Bournia had previously served in the French army. 20. ἐποτρύνωσι. See l. 3 n.
-Page [REF]. etre perexwo whether they should take part in the war. The subj. is used in Deliberative Questions, as in Latin.
-1.  devov v there was danger lest. Cf. [REFn].
-Section 26. Irreg. Compar. of Adj., §§ 117-119 and Adv., § 175. βελτίων, § 120.
-1.  ως is used for οὕτως in the expressions καὶ ὥs even 80, οὐδ ̓ ὦς not 
-even 80.
-NOTES TO PAGES 30-33 
-79 
-1.  or, or as (1. 21), is used with superlatives of adj. or adv. meaning as much as possible, like Latin quam.
-2.  πрiv 8 égeλeiv before they captured it.
-Page [REF]. Told by much, i.e., far more powerful. 5. ἀσθενέστεροι ἢ ὥστε lit. weaker than so as to weak to defend themselves.
-1.  ǹ as.
-• 
-., i.e., too 
-1.  Karà xiλious a thousand at a time; Distributive use of kará. 14. is eiπeiv. See [REFn].
-2.  éπì dovλeia for slavery, i.e., to be slaves.
+2. τὰ δὲ ἄλλα... *in other respects they were free citizens*.
+3. During the wars which followed the French Revolution, the crews often doubled their capital by carrying grain from the Bosphorus to the blockaded towns.
+4. δόξαν Acc. Abs. from Impersonal δοκεῖ *it seems good*: *since they had determined*. Cf. [REFn].
+5. ὅπως... ξυλλήψονται *to arrest*.
+6. ἐπιμελησόμενοι ὅπως... βοήθειαν *to arrange to prevent the Sultan sending help*. Verbs of effort, e.g., ἐπιμελεῖσθαι, πράσσειν *take pains*, φυλάσσεσθαι *take precautions*, take ὅπως with Fut. Ind. ἐπιμελησόμενοι is in the Nom. by sense-construction, ἄριστον εφαίνετο... πλεῖν being equivalent to *they determined to sail*.
+7. ἐφαίνοντο παρασκευαζόμενοι *were clearly making ready*; φαίνομαι εἶναι *I appear to be*; φαίνομαι ὢν *I clearly am*.
+
+
+### Section 21.
+
+Weak Aor. Mid. of λύειν, Ind. ἐλυσάμην, Inf. λύσασθαι, Part. λυσάμενος, [REFs].
+
+χείρ [REFs]. ἀργυροῦς, [REFs].
+
+1. The Turkish guns had a longer range than those of the Greeks, which made the latter unwilling to approach the man-of-war. On the other hand the Turkish gunners were so erratic that Lord Byron remarked on one occasion that they would be more formidable if they did not take aim.
+2. γνώμην ἐποιήσατο *proposed*.
+3. εγέμισαν κληματίδων *they filled with brushwood*.
+4. ἐς τὸ... *getting into the small boat they rowed away*.
+5. οὐ γὰρ ἦν *for it was not possible*.
+6. διὰ τὸ... προσέχειν *owing to the enemy paying attention*. Cf. [REFn]. On several other occasions Canaris repeated the exploit here described.
+7. The Greeks excused these murders on the ground that they were avenging Gregory's execution.
+
+
+### Section 22.
+Pass. Weak Aor. of λύειν, Ind. ἐλύθην, Inf. λυθῆναι, Part. λυθείς, [REFs]; Fut. Ind. λυθήσομαι, Ιnf. λυθήσεσθαι, Part. λυθησόμενος, [REFs].
+
+1. τούτων. Introd. Note A. (ii.).
+2. Demetrius Hypsilantes is thus described by Gordon: "Nature had favoured him more in mind than in his corporeal frame, for his diminutive stature, bald head, awkward carriage, and indistinct utterance, were ill-calculated to win the opinions of those who beheld him. On the other hand it was difficult to know without esteeming him, for even his enemies were forced to confess, that to ardent patriotism he united courage, integrity and humanity, disregarded the allurements of pleasure, and had much goodness of heart, with a steadiness of purpose which at times bordered upon obstinacy."
+"Colokotrones, like his father, had been a clepht. Tall and athletic, with a profusion of black hair and expressive features, alternately lighted up with boisterous gaiety, or darkened by bursts of passion : among the soldiers he seemed born to command, having just the manners and bearing calculated to gain their confidence."
+3. ὧν. Cf. [REFn].
+4. τῶν παρόδων... ἐσκομισθήσεται *to keep watch on the passes to prevent supplies being sent in*. Cf. [REFn].
+5. The camp was situated at Valtetzi, several miles south of Tripolitza.
+6. The moral effect of this victory in encouraging the Greeks was out of all proportion to the losses actually inflicted on the Turks, which amounted to about 400 men.
+
+
+### Section 23.
+
+ανήρ, [REFs]; γυνή, [REFs].
+
+1. ῆν *it was possible*. Cf. [REF].
+2. εἴ τινες... *if any were known to them*, i.e., *they sent to any of those inside whom they knew*.
+3. ἐπὶ τῷ... δέχεσθαι *on condition of receiving*. Cf. [REFn]; [REFn].
+4. The report that a Turkish army was coming turned out to be false.
+
+
+### Section 24.
+
+Pass. and Mid. Perf. Ind. of λύειν, λέλυμαι, Plup. ἐλελύμην, Ιnf. λελύσθαι, Part, λελυμένος, [REFs].
+
+1. ἐν τῷ Νεοκάστρῳ. Navarino had capitulated on 19th Aug. and a dispute arose about searching the Turkish women for jewels which they were supposed to have concealed. "Women wounded with musket balls and sabre cuts rushed to the sea seeking to escape and were deliberately shot. Greeks seized infants from their mothers' breasts and dashed them against the rocks. Children, three and four years old, were hurled living into the sea and left to drown. When the massacre was ended, the dead bodies washed ashore or piled on the beach threatened to cause a pestilence. Phrantzes (a Greek priest) who records these atrocities of his countrymen with shame and indignation, himself hired men to burn the bodies of the victims with the wrecks of some vessels in the harbour." FINLAY.
+2. Colokotrones records in his Memoirs that when he rode into the town his horse "from the walls to the palace never touched the earth,” owing to the accumulation of dead bodies.
+3. τοὺς ἔνδον ἀποκτείνοντες ἐπέπαυντο, lit. *murdering the inhabitants they had then desisted*.
+4. εἴ τι παρελέλειπτο... they plundered all that had been left. Some of the richest families in Greece to-day owe the foundation of their fortunes to the spoil of Tripolitza.
+5. "After the Greeks had been in possession of the city for fortyeight hours, they deliberately collected together about 2,000 persons of every age and sex, but principally women and children, and led them to a ravine in the nearest mountain, where they murdered every soul. . . Some prisoners were spared for a short time to bury the bodies of their slaughtered countrymen, which were putrefying by thousands in almost every house and garden. Even this precaution was too long neglected. The air was already tainted with a deadly miasma and a terrible epidemic soon broke out among the Greeks." FINLAY.
+
+
+## PART III.
+
+### Section 25.
+
+Act. Subj. Pres. of εἶναι, ὦ, [REFs]; of λύειν, λύω, [REFs]; Wk. Aor., λύσω, [REFs]; Str. Aor. of πάσχειν, πάθω; Pres. of ποιεῖν, ποιῶ, [REFs].
+
+Regular Compar. of Adj., [REFs], [REFs], [REFs] and Adverbs, [REFs].
+
+1. ἅμα τῷ ἦρι ἀρχομένῳ *with the beginning of the spring* (see ἔαρ). The Partic. is used as in Latin *ante urbem conditam*: θέρος *summer* includes spring and autumn, and is used of the whole period during which military operations were carried on in ancient times.
+2. ὅπως... ἐσαγάγωσιν *in order to introduce*; ὅπως (or ἵνα) *in order that* with the Subj. expresses purpose. The Aor. in the Subj. Optat. and Imperat. moods is not a past tense: the difference between it and the present is not a difference in *time* but in *kind* of action; the present regards the action as *continuing*, the Aorist regards it simply as *occurring*. Cf. [REF].
+3. τῶν νήσων κρατηθεισῶν, Gen. Abs. expressing a condition, *if the islands were conquered*.
+4. ἐπικινδυνοτάτην εἶχον. See [REFn].
+5. εὐτυχήσαντες. See Sect. 21.
+6. aqytn *than they were*. The Gen. of Comparison is used like the Latin Abl. of Comparison; it is a Gen. of Separation, ἰσχυρότεροι αὐτῶν meaning *stronger starting from them*.
+7. τοῖς πᾶσιν εὐπορωτάτην *excellently provided with everything*. "Celebrated for its fertility and the enchanting aspect of its gardens, Chios carried on a brisk trade in silk and fruit; from thence Constantinople was supplied with oranges, lemons and citrons; but the most valuable production of the country is gum mastic, a substance highly valued by Eastern ladies, who amuse their indolence by chewing it, deriving from that practice as much gratification as their male relations enjoy by inhaling the fumes of tobacco." GORDON.
+8. φοβούμενοι μὴ πάθωσι *fearing that they would suffer*. The object clauses after words of fearing are introduced by μή *lest*, followed by the subj.
+9.  Antonius Bournia had previously served in the French army.
+10. ἐποτρύνωσι. See [REFn].
+11. εἴτε μετέχωσι *whether they should take part in the war*. The subj. is used in Deliberative Questions, as in Latin.
+12. δεινὸν ἦν *there was danger lest*. Cf. [REFn].
+
+
+### Section 26.
+
+Irreg. Compar. of Adj., [REFs] - [REFs] and Adv., [REFs]. βελτίων, [REFs].
+
+1. ὥς is used for οὕτως in the expressions καὶ ὥs *even so*, οὐδ' ὧς *not even so*.
+2. ὅτι, or ὡς [REF], is used with superlatives of adj. or adv. meaning *as much as possible*, like Latin *quam*.
+3. πρὶν δ' ἐξελεῖν *before they captured it*.
+4. πολλῷ *by much*, i.e., *far more powerful*.
+5. ἀσθενέστεροι ἢ ὥστε... lit. *weaker than so as to...*, i.e., *too weak to defend themselves*.
+6. ᾗ *as*.
+7. κατὰ χιλίους *a thousand at a time*; Distributive use of κατά.
+8. ὡς εἰπεῖν. See [REFn].
+9. ἐπὶ δουλείᾳ *for slavery*, i.e., *to be slaves*.
 It is said that out of 100,000 inhabitants of Chios, nearly a third was massacred, and nearly the half enslaved, only 1,800 were still living on the island in August, 1822.
-Section 27. Act. Optat. Pres. of Ave, Avoyu, § 181; Str. Aor. οἱ πάσχειν, πάθοιμι. Numerals, § 122. εἰς, δύο, τρεῖς, τέσσαρες, of § 123.
-1.  OUтws πρatav fared thus. рáσσew, like "do" in English, with adv. means to fare.
-2.  The Albanian Christians, who lived at Souli, had fought on the side of Ali Pasha of Janina; when Ali was killed (Feb., 1822), they had continued the war with some success under Marcus Botzares, but were now being besieged in the Castle of Kiapha, which is the Acropolis of Souli.
-3.  Tapéxou. After an historic tense (Bouλero) the Optative may be used (instead of the Subj.) in final clauses, and with verbs of fearing.
-4.  γνώμῃ 
-inferior to no one in judgment; ovdevós is Gen. of Compar. See [REFn].
-The corps, 
-Page [REF]. The Philhellenes were officers from various European countries, who had volunteered for service in Greece. consisting of about 100 men, was formed to show the Greeks the value of discipline.
-1. yévos by race. Acc. of Respect. Cf. [REF].
-2.  Gogos had greatly distinguished himself in the previous year by repulsing a Turkish attack on Peta.
-3.  φοβούμενος μή EXOLEV. See [REFn].
-• 
-1.  ei. . . κaðégovor if they should control the administration of affairs.
-2.  oi δέ the Turks. Cf. Introd. Note B. (viii.).
-Section 28. Act. Optat. Weak Aor. of Xúew, Xvoa, § 182.
-• 
-Page [REF]. τὸ πολύ ἐξέλθοιεν bear the brunt of the attack.
-fearing that they would no longer effect anything.
-1.  δείσας 
-80 
-NOTES TO PAGES 33-36 
-1.  Most of the Turkish army had been recruited in Albania.
-2.  When two Rel. clauses, referring to the same antecedent (here Aópov), stand side by side, and the second Relative would be in a different case from the first (here first Rel. is ov and second would be ds), the second Rel. is either omitted (as here), or replaced by a Personal Pronoun. Cf. St. Matt. iii. 12, whose fan is in his hand, and he (not who) will throughly purge his floor.
-3.  ὡς σωτηρίας . as each group had hope of safety.
-Page [REF]. roîs de λonoîs with the rest. Cf. [REFn].
-1. ovdeμiâs éláσowv less than none, i.e., worse than any of the calamities in the war.
-2.  The remnant of the Philhellenes was disbanded shortly afterwards. The following incident is related by Gordon: "At noon on 16th July, as Mavrocordato sat at dinner with his suite at Langada, one of the Greek commanders, examining the shoulder-blade of a sheep according to a method of divination practised in the East, declared that their friends had suffered a bloody defeat; this caused some mirth at the seer's expense, until a horseman, while they were still at table, brought news of the battle of Peta". Two days after the battle Gogos went over to the enemy. Some of the Souliotes continued to fight on the Greek side under M. Botzares. See Sect. 35.
-3.  Corcyra (Corfu) was neutral territory, being under the control of an English High Commissioner.
-Section 29.
-1.  There were no houses in Salamis for the accommodation of these refugees, and the landowners showed their patriotism by exacting rent for the privilege of sleeping under an olive-tree.
-Page [REF]. Bpaxéa eixov had their supplies short, i.e., were short of supplies. Cf. [REFn].
-1. ὅπερ id quod.
-2.  oσov où almost, Lat. modo non.
-3.  äλdoi äλda ëλeyov, Lat. alius alia dicebant.
-Section 30. yw, σú, § 128. Act. Imperat. Mood of eivai, lobi, § 266; of λύειν, Pres. λνε, § 181 ; of ποιεῖν, ποίει, § 198; Wk. Aor. of λύειν, λύσον, § 182; Str. Aor. of πάσχειν, πάθε.
-1.  palóvrov let them learn. The 3rd Pers. Plur. of Imperatives is the same in form as the Gen. Plur. of the Participle.
-2.  ĕxovraι kaì ai vñσo the islands too are in their hands; the Present is used graphically for the Future.
-Page [REF]. τίνα ἐλπίδα ἔχοντες 
-.
-• 
-with what hope or with what 
-NOTES TO PAGES 36-38 
-81 
-purpose? The interrogative rís; who? is declined like the indefinite Tis any one, but accented differently, § 151.
-1. πôs où ßλáßŋ (ẻorí); how is it not a loss? i.e., surely it is injurious.
-2. voμion undeís let no one suppose. Prohibitions are expressed by un (or compounds μndeis, unkéti, k.T.λ.) with (i.) the Aor. Subj. or (ii.) the Pres. Imperat. (1. 24).
-3.  puλáoowμev let us guard. The Subj. supplies the missing 1st Pers. Plur. of the Imperat. as in Latin.
-4.  ávax@povσiv, Participle, when they retreat.
-5.  πάντων μάλιστα most of all.
-6.  πάσχειν = βλάπτεσθαι.
-7.  μηκέτι . . . ἔστε do not be alarmed any longer, 1. 5 n. 25. πρὸς ὑμῶν in your favour.
-8.  Evμßýσerai ημiv will happen to us, i.e., will be achieved by us.
-Section 31. Reflex. Pronouns éavróv, opeîs, § 134; Pass. and Mid. Subj. Pres. of λύειν, λύωμαι, § 183 ; of ποιεῖν, ποιῶμαι, § 199 ; Str. Aor. Μid. of γίγνεσθαι, γένωμαι.
-= 
-Page [REF]. rà opérepa avrâv sua, their own property. opérepos is used (i.) as a Direct Reflexive, referring to the subject of the verb in its own clause, or (ii.) as an Indirect Reflexive, used in a Subordinate clause, and referring to the Subject of the main verb. If avrov is added, it is a Direct Reflexive only.
-1. τοὺς ἑαυτοῦ his own men.
-2.  raúry there.
-3.  opas is an Indirect Reflexive, used in a Subordinate clause and referring to the Subject of the main verb.
-4.  οὐ πολὺς 
-there was not much time and Colokotrones arrived, i.e., it was not long before C. arrived.
-1.  τολμηρότεροι ἑαυτῶν γενόμενοι becoming braver than themselves; a common way in Greek of expressing their courage increased.
-2.  oi ek twv μereάpwv, we should say those on the hills; Greek often accommodates the prepos. to the sense of motion expressed in the verb the men came down from the hills.
-3.  ἀσφάλεια τῆς ἐξόδου come away in safety.
-that Hypsilantes and his men might 
-Page [REF]. On the second occasion, one of the Greeks happened to be asleep when his companions evacuated the fort, and was accidentally left behind. Awakened by the noise of the Turks rushing in to plunder, he seized a large copper cauldron, and, putting it over his head to conceal his features, walked boldly out. The Turks, thinking he was one of themselves carrying off loot, let him pass with a few jokes at his ridiculous appearance.-TRICOUPI.
-6 
-82 
-NOTES TO PAGES 38-40 
-Section 32. doris, § 162. Wk. Aor. Subj. of λúeiv, Pass. λvbw, Mid. λύσωμαι, § 183.
-1. προσεδέχοντο should be προσδεχόμενοι, corresponding with φυλάσσοντες, but such slight irregularities are very common. Cf. ἔμελλε in 1. 23.
+
+
+### Section 27.
+
+Act. Optat. Pres. of λύειν, λύοιμι, [REFs]; Str. Aor. of πάσχειν, πάθοιμι. Numerals, [REFs]. εἰς, δύο, τρεῖς, τέσσαρες, [REFs].
+
+1. οὕτως ἔπραξαν *fared thus*. πράσσειν, like "do" in English, with adv. means *to fare*.
+2. The Albanian Christians, who lived at Souli, had fought on the side of Ali Pasha of Janina; when Ali was killed (Feb., 1822), they had continued the war with some success under Marcus Botzares, but were now being besieged in the Castle of Kiapha, which is the Acropolis of Souli.
+3. παρέχοι. After an historic tense (ἐβούλετο) the Optative may be used (instead of the Subj.) in final clauses, and with verbs of fearing [REF].
+4. γνώμῃ... *inferior to no one in judgment*; οὐδενός is Gen. of Compar. See [REFn].
+5. The Philhellenes were officers from various European countries, who had volunteered for service in Greece. The corps, consisting of about 100 men, was formed to show the Greeks the value of discipline.
+6. γένος *by race*. Acc. of Respect. Cf. [REF].
+7. Gogos had greatly distinguished himself in the previous year by repulsing a Turkish attack on Peta.
+8. φοβούμενος μή... ἔχοιεν. See [REFn].
+9. εἰ... καθέξουσι *if they should control the administration of affairs*.
+10. οἱ δέ *the Turks*. Cf. Introd. Note B. (viii.).
+
+
+### Section 28. Act. Optat. Weak Aor. of λύειν, λύσαιμι, [REFs].
+
+1. τὸ πολύ... ἐξέλθοιεν *bear the brunt of the attack*.
+2. δείσας... *fearing that they would no longer effect anything*.
+3. Most of the Turkish army had been recruited in Albania.
+4.  When two Rel. clauses, referring to the same antecedent (here λόφον), stand side by side, and the second Relative would be in a different case from the first (here first Rel. is ὃν and second would be ὃς), the second Rel. is either omitted (as here), or replaced by a Personal Pronoun. Cf. St. Matt. iii. 12, *whose fan is in his hand, and he* (not *who*) *will throughly purge his floor*.
+5. ὡς σωτηρίας... *as each group had hope of safety*.
+6. τοῖς δὲ λοιποῖς *with the rest*. Cf. [REFn].
+7. οὐδεμιᾶς ἐλάσσων *less than none*, i.e., *worse than any of the calamities in the war*.
+8. The remnant of the Philhellenes was disbanded shortly afterwards. The following incident is related by Gordon: "At noon on 16th July, as Mavrocordato sat at dinner with his suite at Langada, one of the Greek commanders, examining the shoulder-blade of a sheep according to a method of divination practised in the East, declared that their friends had suffered a bloody defeat; this caused some mirth at the seer's expense, until a horseman, while they were still at table, brought news of the battle of Peta". Two days after the battle Gogos went over to the enemy. Some of the Souliotes continued to fight on the Greek side under M. Botzares. See Sect. 35.
+9. Corcyra (Corfu) was neutral territory, being under the control of an English High Commissioner.
+
+
+### Section 29.
+
+1. There were no houses in Salamis for the accommodation of these refugees, and the landowners showed their patriotism by exacting rent for the privilege of sleeping under an olive-tree.
+2. βραχέα εἶχον *had their supplies short*, i.e., *were short of supplies*. Cf. [REFn].
+3. ὅπερ *id quod*.
+4. ὅσον οὐ *almost*, Lat. *modo non*.
+5. ἄλλοι ἄλλα ἔλεγον, Lat. *alius alia dicebant*.
+
+
+### Section 30. 
+
+εγώ, σύ, [REFs]. Act. Imperat. Mood of εἶναι, ἴσθι, [REFs]; of λύειν, Pres. λῦε, [REFs]; of ποιεῖν, ποίει, [REFs]; Wk. Aor. of λύειν, λύσον, [REFs]; Str. Aor. of πάσχειν, πάθε.
+
+1. μαθόντων *let them learn*. The 3rd Pers. Plur. of Imperatives is the same in form as the Gen. Plur. of the Participle.
+2. ἔχονται καὶ αἱ νῆσοι *the islands too are in their hands*; the Present is used graphically for the Future.
+3. τίνα ἐλπίδα ἔχοντες... *with what hope or with what purpose*? The interrogative τίς; *who*? is declined like the indefinite τις *any one*, but accented differently, [REFs].
+4. πῶς οὐ βλάβη (ἐστί); *how is it not a loss*? i.e., *surely it is injurious*.
+5. νομίσῃ μηδείς *let no one suppose*. Prohibitions are expressed by μή (or compounds μηδείς, μηκέτι, κ.τ.λ.) with (i.) the Aor. Subj. or (ii.) the Pres. Imperat. [REF].
+6. φυλάσσομεν *let us guard*. The Subj. supplies the missing 1st Pers. Plur. of the Imperat. as in Latin.
+7. αναχωροῦσιν, Participle, *when they retreat*.
+8. πάντων μάλιστα *most of all*.
+9. πάσχειν = βλάπτεσθαι.
+10. μηκέτι... ἔστε *do not be alarmed any longer*, [REFn].
+11. πρὸς ὑμῶν *in your favour*.
+12. ξυμβήσεται ἡμῖν *will happen to us*, i.e., *will be achieved by us*.
+
+
+### Section 31.
+
+Reflex. Pronouns ἑαυτόν, σφιῖς [REFs]; Pass. and Mid. Subj. Pres. of λύειν, λύωμαι, [REFs]; of ποιεῖν, ποιῶμαι, [REFs]; Str. Aor. Μid. of γίγνεσθαι, γένωμαι.
+
+1. τὰ σφέτερα αὐτῶν = *sua*, *their own property*. σφέτερος is used (i.) as a Direct Reflexive, referring to the subject of the verb in its own clause, or (ii.) as an Indirect Reflexive, used in a Subordinate clause, and referring to the Subject of the main verb. If αὐτῶν is added, it is a Direct Reflexive only.
+2. τοὺς ἑαυτοῦ *his own men*.
+3. ταύτῃ *there*.
+4. σφᾶς is an Indirect Reflexive, used in a Subordinate clause and referring to the Subject of the main verb.
+5. οὐ πολὺς... *there was not much time and Colokotrones arrived*, i.e., *it was not long before C. arrived*.
+6. τολμηρότεροι ἑαυτῶν γενόμενοι *becoming braver than themselves*; a common way in Greek of expressing *their courage increased*.
+7. οἱ ἐκ τῶν μετεώρων, we should say *those on the hills*; Greek often accommodates the prepos. to the sense of motion expressed in the verb the men came down *from* the hills.
+8. ἀσφάλεια τῆς ἐξόδου... *that Hypsilantes and his men might come away in safety*.
+9. On the second occasion, one of the Greeks happened to be asleep when his companions evacuated the fort, and was accidentally left behind. Awakened by the noise of the Turks rushing in to plunder, he seized a large copper cauldron, and, putting it over his head to conceal his features, walked boldly out. The Turks, thinking he was one of themselves carrying off loot, let him pass with a few jokes at his ridiculous appearance. TRICOUPI.
+
+
+### Section 32.
+
+doris, [REFs]. Wk. Aor. Subj. of λύειν, Pass. λυθῶ, Mid. λύσωμαι, [REFs].
+
+1. προσεδέχοντο should be προσδεχόμενοι, corresponding with φυλάσσοντες, but such slight irregularities are very common. Cf. ἔμελλε in [REF].
 2. The Turkish fleet which should have brought supplies sailed away to Patras owing to the Admiral's jealousy of Dramali.
-• 
-1.  τὰ τῶν πολεμίων . seeing the affairs of the enemy in what state they are, i.e., seeing in what state the enemy are.
-For the order of words, by which rà râv Toλeμíov is made the Object of idóvres instead of being placed in the dependent clause as Subject, compare St. Mark i. 24, I know thee who thou art. oris introduces an Indirect Question ; the Direct Question was ἐν τίνι ἐστὶ τὰ τῶν πολεμίων ; in what state are the enemy's affairs? Greek retains the original tense (éori), just as it does in or clauses. See [REFn].
-Dramali's difficulties were much increased owing to the season being singularly dry. Disease broke out among his men, who were living mainly on green grapes and unripe melons.
-1.  οἵτινες 
-ποιήσονται to make an ambuscade : ὅστις with Fut.
-Indic. expresses purpose.
-1.  τὰ χαλεπώτατα . the most difficult points in the pass.
-2.  ποιήσωνται 
-• 
-• 
-κρατήσειαν, after an historic tense, όπως may take the Subj. ([REFn].) or the Optat. ([REFn].); occasionally, as here, both are used: there is no difference in meaning.
-1.  hy it was possible.
-Page [REF]. oжоi тpáñwvrai where to turn; Delib. Subj., see 30, 
-9 n.
-και 
-• • 
-καί 
-• 
-• 
-both . . . and.
-Section 33.
-1.  ἰδὼν 
-2.  τοὐναντίον 
-guarding.
-• 
-πрáyμara seeing the state of affairs. Cf. [REFn].
-the opposite way to that which the enemy were 
-1.  oirives since they; ooris, besides being an Indirect Interrogative Pronoun, is used (i.) to express cause, as here; (ii.) with Fut. Ind. to express purpose, [REFn].; and (iii.) as an Indefinite Rel. Pron. meaning whoever, 1. 19.
-2.  το πολύ 
-= 
-oi rooi the majority.
-Page [REF]. The state of these fugitives is thus described by Gordon : "The famishing soldiers, after eating all their horses, existed on the flesh of their dead comrades, and even fought over their graves", 
-NOTES TO PAGES 40-43 
-83 
-Section 34. Pass. and Mid. Optat. Pres. of Xúeiv, Avoiμnv, § 183; οι ποιεῖν, ποιοίμην, § 199; Str. Aor. Mid. of γίγνεσθαι, γενοίμην.
-1.  These Albanians were Christians, serving as mercenaries to the Turks. They spoke the same dialect and wore the same dress as M. Botzares and his Souliotes.
-2.  For M. Botzares, see [REFn].
-3.  πεῖραν ποιεῖσθαι, see [REF] η.
-4.  ἂν ἐπιφέροιντο they would attack; ἂν gives to the Optative s Potential sense, expressed in English by would, might or could. Page [REF]. öпоi тρáπото where to turn; after an historic tense, the Optat. may be substituted for the Delib. Subj. in Indirect Questions. The original question was roî rparwμela; where are we to turn? Cf. [REF].
-Section 35. Pass. and Mid. Imperat. Pres. of λúeiv, λvov; Wk. Aor. Mid. λῦσαι ; Wk. Aor. Pass. λύθητι, § 183 ; Str. Aor. Mid. of γίγνεσθαι, γένου ; Pres. of ποιεῖν, ποιοῦ, § 199.
-1.  avrov on the spot.
-Page [REF]. oirives since they. Cf. [REFn].
-1.  μn éкπλaynτe do not be alarmed. See [REFn].
-2.  πλήθει ελάσσους inferior in numbers.
-3.  un avopeious ovo if we are not brave; the Neg. is μn (not oỷ), because the Participle expresses a condition.
-4.  πρὸς ἡμῶν on our side. Cf. [REF].
-5.  Teρì rλeiorov moɩîode, lit. regard above very much, i.e., regard as of the greatest importance.
-Section 36. Optat. Pres. of eivai, einv, § 266; Optat. Wk. Aor. Ρass. οἱ λύειν, λυθείην, Μid. λυσαίμην, Fut. λυσοίμην, § 183.
-1.  ei Bovλoμένo poí èori, lit. whether it is to me being willing, i.e., whether I am willing; compare Lat. quibus bellum volentibus erat.
-2.  δέxeσbai Tŷ móλei admit into the city; the Dat. Tóλe is Instrumental, literally, receive with the city; the Instrum. Abl. in Lat. is used similarly with recipere.
-3.  ǎoμevos âv dekaiμŋv I would gladly admit him: we translate the predicated Adjective douevos by an Adverb. Cf. Lat. primus hoc feci, I did it first, and reλevraîos, [REF].
-4.  após in answer to.
-Page [REF]. Tepì râv 'Eλλŋvikov with regard to the Greek War; τὰ  ̔Ελληνικά is the subject of μέλλει. See [REF] η.
-1. Karapaivoivтo are in sight. In a clause introduced by ori (that), the Optat. may be substituted for the original Indicative, if the tense 
-84 
-NOTES TO PAGES [REF] 
-of the main verb is historic (here hλ0). Notice that though the mood is altered, the tense remains the same; the original message was oi Τοῦρκοι καταφαίνονται. Cf. [REF] η.
-1. εἰ ἐλπίζοιεν whether they hoped; ἐλπίζοιεν in the original question was ἐλπίζουσι.
-2.  és rà μádiora in the highest degree. 13. εἶμεν 
-φοβοίμεθα .
-εἴη 
-• 
-ἀναγκασθεῖμεν 
-What were these words in the original statement ? 
-1.  Bovλóuevos if you are willing.
-2.  οὐκ ἴδιον ..the lead he had was not his own.
-ἔχοι.
-Cf. [REFn].
-1.  βουλεύσοιτο, he actually said βουλεύσομαι I'll think about it.
-2.  or sometimes introduces the original words, and is represented 
-in English by inverted commas.
-Toù oivov, Partitive Gen. some wine.
-• 
-1.  ξυνενέγκοι may everything turn out as we wish. The Optat. by itself in a Principal Sentence expresses a wish; hence its 
-name.
-: 
-The Turks subsequently advanced to Anatolicon, a small town situated in the lagoons, about five miles west of Messalonghi. The inhabitants had been accustomed to get their supplies of drinkingwater from the mainland, as there were no springs on the island of this the Turks were aware, and therefore expected to force it to surrender quickly. A Turkish shell, however, happened to fall on the Church of St. Michael, and, breaking through the pavement, disclosed a spring, which not only supplied sufficient water, but encouraged the people to think that a miracle had been performed on their behalf. After about a month the Turks abandoned the siege.
-PART IV.
-Section 37. ripâv, §§ [REF].
-Page [REF]. Tapà yváμny contrary to expectation.
-1. ὅπερ 
-which no one would have believed, if he had been told, before it happened. av is used with the Past Tenses of the Indic. in 
-a Potential sense, expressing might have, would have, could have.
-Cf. [REFn].
-β. τὰ μέν 
-times.
-• 
-Tà de partly.
-partly, or sometimes 
-• • • 
-at other 
-NOTES TO PAGES [REF] 
-85 
-1.  As an instance of Byron's energy, the following story may be quoted. When he was at Cephalonia, a number of workmen engaged in excavating were buried by the fall of a mass of earth. Byron heard of the accident while at dinner, and rushing to the place seized a spade and by his example stimulated the panic-stricken onlookers to set to work. The result was that all the workmen were rescued.
-2.  The Ionian islands, being under the protection of England, were the chief place of refuge for those Greeks who had been driven from their homes by the Turks. Cf. [REFn].
-3.  âs av vaûs whatever ships they had. av, joined to Rel. pronouns or conjunctions, and followed by the Subjunctive, gives an Indefinite Sense, expressed in English by ever.
-Page [REF]. On 30th December Byron and Count Gamba (an Italian) with their baggage and a large sum of money set sail in separate ships. Byron's ship fell in with a Turkish frigate, but succeeded in getting away to some rocky islands called Scrofes, where Byron concealed himself in a cave. Gamba and his ship were captured, but by a curious coincidence the captain of the Turkish frigate had once been saved from death by the Greek skipper, and, in gratitude for this, he pretended that he saw nothing suspicious about the vessel, and let it continue its voyage.
-Section 38. v, Xpĥodai, § 232. Contracted Futures, §§ [REF] (i.).
-1.  See Sections [REF].
-2.  οὔτε ὅθεν κομιοῦνται nor having whence they shall get rations, i.e., not being able to get rations.
-3.  čσTIV OTE sometimes. Cf. 1. 25. čσri in some places.
-4.  The disorder culminated in the following incident: A Souliote, noted for his bravery, came to the armoury with a young son of M. Botzares, and, having no written permission to enter, was stopped by the sentry. He persisted in going in, and the officer on guard ordered him to be arrested; a quarrel ensued, and the Souliote, having received a blow, killed the officer on the spot. In an instant alarm pervaded the town: the Souliotes rose to arms, threatening to storm the armoury and even Byron's house, if their countryman, who had been apprehended, was not set at liberty. The riot was at length appeased, but Byron declared that he would return to the Ionian islands if the Souliotes did not leave Messalonghi.—GORDON.
-Γρασσεν ὅπως 
-1.  ἔπρ 
-• 
-took steps to make the place secure. Verbs 
-of Effort take oπws with Fut. Indic. Cf. [REFn].
-1.  oux egovo oros will not be able to. Cf. 1. 13 n.
-2.  eis is used emphatically with Superlatives, this man of all others, like Lat. unus.
-86 
-NOTES TO PAGES 45-47 
-1.  tŵv ka✪ ¿avróv of his contemporaries.
-On 9th April Byron went out to ride near the town and was overtaken by a heavy shower, and returned home in a boat. Shortly afterwards he complained of fever: the doctors prescribed bleeding, but he refused, saying, “I will drink all your medicines, but not one drop of my blood will I shed. All of it shall be shed on the field of battle." Delirium came on, then stupor, and at six o'clock in the afternoon of Easter Monday (19th April) at the instant of an awful thunderstorm Byron expired.
+3. τὰ τῶν πολεμίων... *seeing the affairs of the enemy in what state they are*, i.e., *seeing in what state the enemy are*. For the order of words, by which τὰ τῶν πολεμίων is made the Object of ἰδόντες instead of being placed in the dependent clause as Subject, compare St. Mark i. 24, *I know thee who thou art*. ὅστις introduces an Indirect Question ; the Direct Question was ἐν τίνι ἐστὶ τὰ τῶν πολεμίων; *in what state are the enemy's affairs*? Greek retains the original tense (ἐστί), just as it does in ὅτι clauses. See [REFn].
+4. Dramali's difficulties were much increased owing to the season being singularly dry. Disease broke out among his men, who were living mainly on green grapes and unripe melons.
+5. οἵτινες... ποιήσονται *to make an ambuscade*: ὅστις with Fut. Indic. expresses *purpose*.
+6. τὰ χαλεπώτατα... *the most difficult points in the pass*.
+7.  ποιήσωνται... κρατήσειαν, after an historic tense, ὅπως may take the Subj. ([REFn].) or the Optat. ([REFn].); occasionally, as here, both are used: there is no difference in meaning.
+8. ἦν *it was possible*.
+9. ὅποι τράπωνται *where to turn*; Delib. Subj., see [REFn]
+10. καί... καί... *both... and*....
+
+
+### Section 33.
+
+1. ἰδὼν... πράγματα *seeing the state of affairs*. Cf. [REFn].
+2. τοὐναντίον... *the opposite way to that which the enemy were guarding*.
+3. οἵτινες *since they*; ὅστις, besides being an Indirect Interrogative Pronoun, is used (i.) to express *cause*, as here; (ii.) with Fut. Ind. to express *purpose*, [REFn].; and (iii.) as an Indefinite Rel. Pron. meaning *whoever*, [REF].
+4. τὸ πολύ = οἱ πολλοί *the majority*.
+5. The state of these fugitives is thus described by Gordon: "The famishing soldiers, after eating all their horses, existed on the flesh of their dead comrades, and even fought over their graves".
+
+
+### Section 34.
+
+Pass. and Mid. Optat. Pres. of λύειν, λυοίμην, [REFs]; of ποιεῖν, ποιοίμην, [REFs]; Str. Aor. Mid. of γίγνεσθαι, γενοίμην.
+
+1. These Albanians were Christians, serving as mercenaries to the Turks. They spoke the same dialect and wore the same dress as M. Botzares and his Souliotes.
+2. For M. Botzares, see [REFn].
+3. πεῖραν ποιεῖσθαι, see [REFn].
+4. ἂν ἐπιφέροιντο *they would attack*; ἂν gives to the Optative a Potential sense, expressed in English by *would*, *might* or *could*.
+5. ὅποι τράποιντο *where to turn*; after an historic tense, the Optat. may be substituted for the Delib. Subj. in Indirect Questions. The original question was ποῖ τραποώμεθα; *where are we to turn*? Cf. [REF].
+
+
+### Section 35.
+
+Pass. and Mid. Imperat. Pres. of λύειν, λύου; Wk. Aor. Mid. λῦσαι; Wk. Aor. Pass. λύθητι, [REFs]; Str. Aor. Mid. of γίγνεσθαι, γένου ; Pres. of ποιεῖν, ποιοῦ, [REFs].
+
+1. αὐτοῦ *on the spot*.
+2. οἵτινες *since they*. Cf. [REFn].
+3. μὴ ἐκπλαγῆτε *do not be alarmed*. See [REFn].
+4. πλήθει ελάσσους *inferior in numbers*.
+5. μὴ ἀνδρείοις οὖσι *if we are not brave*; the Neg. is μή (not οὐ), because the Participle expresses a condition.
+6. πρὸς ἡμῶν *on our side*. Cf. [REF].
+7. περὶ πλείστου ποιεῖσθε, lit. *regard above very much*, i.e., *regard as of the greatest importance*.
+
+
+### Section 36.
+
+Optat. Pres. of εἶναι, εἴην, [REFs]; Optat. Wk. Aor. Ρass. of λύειν, λυθείην, Μid. λυσαίμην, Fut. λυσοίμην, [REFs].
+
+1. εἰ βουλομένῳ μοί ἐστι, lit. *whether it is to me being willing*, i.e., *whether I am willing*; compare Lat. *quibus bellum volentibus erat*.
+2. δέχεσθαι τῇ πόλει *admit into the city*; the Dat. Tπόλειóλe is Instrumental, literally, *receive with the city*; the Instrum. Abl. in Lat. is used similarly with *recipere*.
+3. ἄσμενος ἂν δεξαίμην *I would gladly admit him*: we translate the predicated Adjective ἄσμενος by an Adverb. Cf. Lat. *primus hoc feci*, *I did it first*, and τελευταῖος, [REF].
+4. πρός *in answer to*.
+5. περὶ τῶν Ἑλληνικῶν *with regard to the Greek War*; τὰ Ἑλληνικά is the subject of μέλλει. See [REFn].
+6. καταφαίνοιντο *are in sight*. In a clause introduced by ὅτι (*that*), the Optat. may be substituted for the original Indicative, if the tense of the main verb is historic (here ἦλθε). Notice that though the *mood* is altered, the tense remains the same; the original message was οἱ Τοῦρκοι καταφαίνονται. Cf. [REF]n.
+7. εἰ ἐλπίζοιεν *whether they hoped*; ἐλπίζοιεν in the original question was ἐλπίζουσι.
+8. ες τὰ μάλιστα *in the highest degree*.
+9. εἶμεν... φοβοίμεθα... εἴη... ἀναγκασθεῖμεν... ἔχοι. What were these words in the original statement?
+10. βουλόμενος *if you are willing*.
+11. οὐκ ἴδιον... *the lead he had was not his own*.Cf. [REFn].
+12. βουλεύσοιτο, he actually said βουλεύσομαι *I'll think about it*.
+13. ὅτι sometimes introduces the original words, and is represented in English by inverted commas.
+14. τοῦ οἴνου, Partitive Gen. *some wine*.
+15. ξυνενέγκοι... *may everything turn out as we wish*. The Optat. by itself in a Principal Sentence expresses a wish; hence its name.
+16. The Turks subsequently advanced to Anatolicon, a small town situated in the lagoons, about five miles west of Messalonghi. The inhabitants had been accustomed to get their supplies of drinkingwater from the mainland, as there were no springs on the island of this the Turks were aware, and therefore expected to force it to surrender quickly. A Turkish shell, however, happened to fall on the Church of St. Michael, and, breaking through the pavement, disclosed a spring, which not only supplied sufficient water, but encouraged the people to think that a miracle had been performed on their behalf. After about a month the Turks abandoned the siege.
+
+
+## PART IV.
+
+### Section 37.
+
+τιμᾶν, [REFs].
+
+1. παρὰ γνώμην *contrary to expectation*.
+2. ὅπερ... *which no one would have believed, if he had been told, before it happened*. ἄν is used with the Past Tenses of the Indic. in a Potential sense, expressing might have, would have, could have. Cf. [REFn].
+3. τὰ μέν... τὰ δὲ *partly... partly*, or *sometimes... at other times*.
+4. As an instance of Byron's energy, the following story may be quoted. When he was at Cephalonia, a number of workmen engaged in excavating were buried by the fall of a mass of earth. Byron heard of the accident while at dinner, and rushing to the place seized a spade and by his example stimulated the panic-stricken onlookers to set to work. The result was that all the workmen were rescued.
+5. The Ionian islands, being under the protection of England, were the chief place of refuge for those Greeks who had been driven from their homes by the Turks. Cf. [REFn].
+6. ἃς ἂν ναῦς *whatever ships they had*. ἄν, joined to Rel. pronouns or conjunctions, and followed by the Subjunctive, gives an Indefinite Sense, expressed in English by *ever*.
+7. On 30th December Byron and Count Gamba (an Italian) with their baggage and a large sum of money set sail in separate ships. Byron's ship fell in with a Turkish frigate, but succeeded in getting away to some rocky islands called Scrofes, where Byron concealed himself in a cave. Gamba and his ship were captured, but by a curious coincidence the captain of the Turkish frigate had once been saved from death by the Greek skipper, and, in gratitude for this, he pretended that he saw nothing suspicious about the vessel, and let it continue its voyage.
+
+
+### Section 38.
+
+ζῆν, χρῆσθαι, [REFs]. Contracted Futures, [REFs].
+
+1. See [REF].
+2. οὔτε ὅθεν... κομιοῦνται *nor having whence they shall get rations*, i.e., *not being able to get rations*.
+3. ἔστιν ὅτε *sometimes*. Cf. [REF]. ἔστιν ᾗ *in some places*.
+4. The disorder culminated in the following incident: A Souliote, noted for his bravery, came to the armoury with a young son of M. Botzares, and, having no written permission to enter, was stopped by the sentry. He persisted in going in, and the officer on guard ordered him to be arrested; a quarrel ensued, and the Souliote, having received a blow, killed the officer on the spot. In an instant alarm pervaded the town: the Souliotes rose to arms, threatening to storm the armoury and even Byron's house, if their countryman, who had been apprehended, was not set at liberty. The riot was at length appeased, but Byron declared that he would return to the Ionian islands if the Souliotes did not leave Messalonghi. GORDON.
+5. ἔπροσσεν ὅπως... *took steps to make the place secure*. Verbs of Effort take ὅπως with Fut. Indic. Cf. [REFn].
+6. οὐχ ἕξουσιν ὅπως *will not be able to*. Cf. [REFn].
+7. εἶς is used emphatically with Superlatives, *this man of all others*, like Lat. *unus*.
+8. τῶν καθ' ἑαυτόν *of his contemporaries*.
+9. On 9th April Byron went out to ride near the town and was overtaken by a heavy shower, and returned home in a boat. Shortly afterwards he complained of fever: the doctors prescribed bleeding, but he refused, saying, “I will drink all your medicines, but not one drop of my blood will I shed. All of it shall be shed on the field of battle." Delirium came on, then stupor, and at six o'clock in the afternoon of Easter Monday (19th April) at the instant of an awful thunderstorm Byron expired.
 His coffin was laid by the side of the grave of M. Botzares, but as he expressed a wish to be buried in the tomb of his ancestors (at Hucknall Torkard, near Nottingham), the body was removed to England, and his heart interred at Messalonghi.
-Section 39. dnλoûv, §§ [REF].
-Page [REF]. τὰ ἑαυτῶν regarding only their own interests. 14. rois Xpημaoi from lack of money. Instrum. Dat.
-1.  oơa av δέŋ whatever was necessary. See [REFn].
-2.  A committee was formed in London, including Jeremy Bentham, Joseph Hume and T. Gordon (the historian of the war), and a loan amounting to £300,000 was raised. The security was very bad, and, in fact, the interest was never paid, but by a fortunate coincidence for Greek liberty, a mania for every kind of wild speculation had just then seized English capitalists.
-3.  A talent was a sum of money worth 6,000 drachmæ or £210 in English money. A drachma = a franc.
-4.  öσa λáßolev whatever money they got; after an historic tense (édarávwv), the Rel. followed by the Optat. is used in an Indefinite Sense. After a Primary tense, this would be ora âv λáßwσi. Cf. 1. 17.
-Page [REF]. ek toû roloúrov, by such conduct.
-"Every man of consideration in his own imagination wanted to place himself at the head of a band of armed men, and hundreds of civilians paraded the streets of Nauplia with trains of kilted followers, like Scottish chieftains. Phanariots and doctors of medicine, who in the month of April were clad in ragged coats, and who lived on scanty rations, threw off that patriotic chrysalis before summer was past, and emerged in all the splendour of brigand life, refulgent with brilliant but unused arms, fluttering about in rich Albanian habiliments, and followed by diminutive pipe-bearers and tall henchmen.FINLAY.
-Section 40. ioráva, Act. Voice, § 248.
-The Str. Aor., Perf., and 
-1. ἀντέστη αὐτῷ went against him. Plup. of iorával and its compounds are Intrans.
-NOTES TO PAGES [REF] 
-= 
-87 
-1. és áropíav karaσrĥoai = to reduce to helplessness (Wk. Aor.).
-ἐς ἀπορίαν καταστῆναι to be reduced to helplessness (Str. Aor.). 6. evpnrai Delib. Subj.; evporo might have been used. See [REFn]. "Mehemet-Ali was a determined reformer, although his reforms, like those of all Eastern despots, were directed solely to two pointsaugmenting his revenue, and forming a disciplined standing army. The first he brought about by a most horrible system of oppression and monopoly, turning the cultivators into bondsmen and making himself the only merchant and landowner in the country; the second he effected by establishing an arbitrary conscription among the Arab villagers, and purchasing the services of European instructors." GORDON.
-1. τὰ τῆς χώρας . . . ἐς τὸ ἐπιτήδειον controlling the organisation of the country, he arranged matters to his own advantage.
-2. ὅδεv by which course.
-3.  ὅταν 
-whenever occasion should arise; Temporal Conjunctions compounded with ἄν (ὅταν, ὁπόταν, ἐπειδάν), followed by the Subj. have an Indefinite sense, expressed in English by ever. ever has one of two meanings :
-= 
-This 
-(i.) It refers to one occasion in the unknown future, e.g., whenever 
-at any time when) I die, I shall be cremated.
-(ii.) It refers to an unknown number of occasions, e.g., whenever (= at every time when) I am hungry, I eat.
-ὅταν is used in sense (i.); ὁπόταν in sense (ii.); ἐπειδάν in either 
-sense.
-See 11. [REF].
-1.  éteidη úñéσrn since he had undertaken the expedition.
-2.  ὁπότε 
-Xooler whenever they came to close quarters; after an historic tense, őre, óñóre, and éradý, followed by the Optat. are used in the same Indefinite sense, as orav, órórav, and éπeiðáv, with the Subj. See 1. 13 n. Compare the use of the Relative, [REFn].
-Page, [REF]. δέov, Acc. Abs. See [REFn].
-Section 41. iorával Mid. and Pass., § 249. Súvapai I am able, éniorapai I know, are conjugated like iorapai, but see § 256.
-1.  ἕως ἂν reipŵvrai until they should try; ews åv so long as or until, péxpi av (or μéxpi ov äv) until, followed by the Subj., have an Indefinite sense, not expressed in English. They refer :
-:
-(i.) to one occasion in the unknown future, e.g., we will work, till we have finished.
-(ii.) to an unknown period of time, e.g., while there is life, there is hope.
-After an historic tense, the same Indefinite sense is expressed by ews, μéxpi (or μéxpi ov), followed by the Optat. Compare [REFn], 26 n.
-888 
-NOTES TO PAGES 48-50 
-1.  Tois éπixεiρhμaoi, Instrum. Dat. they were not successful in (lit. by) their efforts.
-2.  οὐκ ἔχοντες 
-not having a point at which they should make a stand, i.e., a rallying point.
-Page [REF]. ews ȧvaykaσbeiev. See [REFn].
-1.
-At four o'clock in the afternoon, a soldier, bearing a lighted match, was seen to leave the monastery and run towards the entrance of a great subterraneous magazine, situated outside-he fell, pierced with balls, and five of his companions, following his example, one after the other, shared his fate. Unable to execute their first project, the Greeks resolved to inflame the powder they had within the monastery. They ceased their fire, and the Turks darting on, sword in hand, scaled the walls on every side; when suddenly the Hellenic flag was lowered, a white banner, inscribed with the words 'Liberty or Death,' waved in the air, a single gun gave the signal, and a tremendous explosion, shaking the island and felt far out at sea, buried in the ruins of St. Nicholas thousands of the conquerors and the conquered!"-Gordon.
-Section 42. δεικνύναι, §§ [REF].
+
+### Section 39.
+
+δηλοῦν, [REFs].
+
+1. τὰ ἑαυτῶν... *regarding only their own interests*.
+2. τοῖς χήμασι *from lack of money*. Instrum. Dat.
+3. ὅσα ἂν δέῃ *whatever was necessary*. See [REFn].
+4. A committee was formed in London, including Jeremy Bentham, Joseph Hume and T. Gordon (the historian of the war), and a loan amounting to £300,000 was raised. The security was very bad, and, in fact, the interest was never paid, but by a fortunate coincidence for Greek liberty, a mania for every kind of wild speculation had just then seized English capitalists.
+5. A talent was a sum of money worth 6,000 drachmæ or £210 in English money. A drachma = a franc.
+6. ὅσα λάβοιεν *whatever money they got*; after an historic tense (ἐδαπάντων), the Rel. followed by the Optat. is used in an Indefinite Sense. After a Primary tense, this would be ὅσα ἂν λάβωσι. Cf. [REF].
+7. εκ τοῦ τοιούτου, *by such conduct*.
+8. "Every man of consideration in his own imagination wanted to place himself at the head of a band of armed men, and hundreds of civilians paraded the streets of Nauplia with trains of kilted followers, like Scottish chieftains. Phanariots and doctors of medicine, who in the month of April were clad in ragged coats, and who lived on scanty rations, threw off that patriotic chrysalis before summer was past, and emerged in all the splendour of brigand life, refulgent with brilliant but unused arms, fluttering about in rich Albanian habiliments, and followed by diminutive pipe-bearers and tall henchmen. FINLAY.
+
+
+### Section 40.
+
+ἱστάναι, Act. Voice, [REFs].
+ 
+1. ἀντέστη αὐτῷ *went against him*. The Str. Aor., Perf., andPlup. of ἱστάναι and its compounds are Intrans.
+2. ἐς ἀπορίαν καταστῆσαι = to reduce to helplessness (Wk. Aor.). ἐς ἀπορίαν καταστῆναι = to be reduced to helplessness (Str. Aor.).
+3. εὕρηται Delib. Subj.; εὕποιτο might have been used. See [REFn].
+4. "Mehemet-Ali was a determined reformer, although his reforms, like those of all Eastern despots, were directed solely to two points: augmenting his revenue, and forming a disciplined standing army. The first he brought about by a most horrible system of oppression and monopoly, turning the cultivators into bondsmen and making himself the only merchant and landowner in the country; the second he effected by establishing an arbitrary conscription among the Arab villagers, and purchasing the services of European instructors." GORDON.
+5. τὰ τῆς χώρας... ἐς τὸ ἐπιτήδειον *controlling the organisation of the country, he arranged matters to his own advantage*.
+6. ὅθεv *by which course*.
+7. ὅταν... ᾗ *whenever occasion should arise*; Temporal Conjunctions compounded with ἄν (ὅταν, ὁπόταν, ἐπειδάν), followed by the Subj. have an Indefinite sense, expressed in English by *ever*. This ever has one of two meanings:
+   1. It refers to *one* occasion in the unknown future, e.g., whenever (= at any time when) I die, I shall be cremated.
+   2. It refers to an unknown number of occasions, e.g., whenever (= at every time when) I am hungry, I eat.
+   ὅταν is used in sense (i.); ὁπόταν in sense (ii.); ἐπειδάν in either sense. See [REF].
+8. επειδὴ ὑπέστη *since he had undertaken the expedition*.
+9. ὁπότε... ἔλθοιεν *whenever they came to close quarters*; after an historic tense, ὅτε, ὁπότε, and ἐπειδή, followed by the Optat. are used in the same Indefinite sense, as ὅταν, ὁπόταν, and ἐπειδάν, with the Subj. See [REFn]. Compare the use of the Relative, [REFn].
+10. δέov, Acc. Abs. See [REFn].
+
+
+### Section 41. ἱστάναι Mid. and Pass., [REFs]. δύναμαι I am able, ἐπίσταμαι I know, are conjugated like ἵσταμαι, but see [REFs].
+
+1. ἕως ἄν... πειρῶνται *until they should try*; ἕως ἄν *so long as* or *until*, μέχρι ἄν (or μέχρι οὗ ἄν) *until*, followed by the Subj., have an Indefinite sense, not expressed in English. They refer:
+   1. to one occasion in the unknown future, e.g., we will work, till we have finished.
+   2. to an unknown period of time, e.g., while there is life, there is hope.
+   After an historic tense, the same Indefinite sense is expressed by ἕως, μέχρι (or μέχρι οὗ), followed by the Optat. Compare [REFn], [REFn]
+2. τοῖς ἐπιχειρήμασιν, Instrum. Dat. *they were not successful in* (lit. *by*) *their efforts*.
+3. οὐκ ἔχοντες... *not having a point at which they should make a stand*, i.e., *a rallying point*.
+4. ἕως ἀναγκασθεῖν. See [REFn].
+5. At four o'clock in the afternoon, a soldier, bearing a lighted match, was seen to leave the monastery and run towards the entrance of a great subterraneous magazine, situated outside-he fell, pierced with balls, and five of his companions, following his example, one after the other, shared his fate. Unable to execute their first project, the Greeks resolved to inflame the powder they had within the monastery. They ceased their fire, and the Turks darting on, sword in hand, scaled the walls on every side; when suddenly the Hellenic flag was lowered, a white banner, inscribed with the words 'Liberty or Death,' waved in the air, a single gun gave the signal, and a tremendous explosion, shaking the island and felt far out at sea, buried in the ruins of St. Nicholas thousands of the conquerors and the conquered!" Gordon.
+
+
+### Section 42. δεικνύναι, [REFs].
+
 1.  A desultory siege of Patras continued throughout the war.
-the management of the loan was not in accordance 
-1.  τὰ περί . with their views.
-2.  πρίν . Karaλvσelav until they should overthrow the existing democracy. The Greeks had elected representatives, but great confusion had arisen owing to party quarrels. If the main verb is negatived, and où æρív not before means not until, æpív takes the same construction as μéxp and ews, [REFn]. When рiv means before, it takes the Infin.
-Page [REF]. οὐ πρότερον πρίν 
-• • 
-not until; the Indic. is used referring to a Definite time, as is the case with all temporal conjunctions.
-1. διὰ τόν τε θάνατον 
-• 
-καὶ ὅτι (a) owing to his son's death, and (b) because the conspirators were unsuccessful. Cf. [REFn].
-1.  καθίστατο τοῖς ἐν τοῖς ἀγροῖς befel the rural population.
-2.  διὰ τὸ ποιεῖσθαι. Cf. [REF] η.
-It was owing to this Civil War that no assistance had been sent to Cassos and Psara.
-Section 43. iévai Indic. Mood, § 267.
-1.  Neocastron, situated on the mainland opposite the south end of Sphakteria, is generally known as Navarino, from some merchants who came from Navarre and settled there in the fifteenth century.
-NOTES TO PAGES [REF] 
-89 
-Page [REF]. διὰ μáxns iévai to fight. Cf. διὰ þóßov eivai to be afraid, [REF].
-diá in such phrases expresses the circumstances, lit. to come into a state of battle.
-1. Tolavrηs i.e., against disciplined troops.
-2.  Sphakteria is famous as the scene of the Spartan surrender in B.C. 425.
-3.  karà tòv Xiμένa on the harbour side.
-4.  Mavrocordato, being a slow runner, would have been taken prisoner had not two soldiers helped him along, and got him on board a vessel from Hydra, named the Mars. For six hours he sat in the cabin, holding a pistol which might save him the ignominy of being sent in chains to Constantinople; he uttered no word except now and then a brief sentence expressive of the vanity of ambition, and a resolution, if he survived, to retire into private life. Meanwhile the Mars fought her way out of the harbour; the Turkish ships did not dare to approach too near, as the Greek captain could be seen standing with a lighted torch ready to blow up the ship, if any attempt was made to board her.-FINLAY.
-Section 44. lévai (all), § 267.
-1.  d' are is used with the Fut. Indic. to express on condition that. The Pres. Ind. of iéval (and its compounds) has a future meaning: the Past Imperfect and the other moods supply the missing forms of ἔρχομαι.
-OTOι av Boúλwvrau whithersoever they wished (lit. shall wish).
-• 
-Page [REF]. ei èmíoiev if ever the enemy attacked; after an historic tense, ei with the Optat. expresses if ever. Cf. [REFn]. When the main verb is primary, the same meaning is expressed by v (= ei av), followed by the Subj. Cf. L. 8 and [REFn].
-1. Tapà λóyov contrary to expectation.
-· 
-1. τήν τε πόλιν they burnt (a) the town, and (b) whatever they could not carry away. See [REFn].
-2.  v πws if perchance, i.e., in hopes that; after an historic tense, this might be el mos with Optat. Cf. [REF].
-3.  When Colokotrones was imprisoned (see [REF]), he exclaimed, "I have twice saved my country, and shall be called upon to save it a third time".-GORDON.
-4.  The Greeks were so demoralised that Colokotrones had great difficulty in keeping his men together. On one occasion his scouts rushed in crying, "Back, back, there are horsemen in the olive-yard". Presently, however, the horsemen were transformed into a flock of crows and flew away.-TRICOUPI.
-5.  During this expedition Ibrahim advanced nearly as far as Argos.
-90 
-NOTES TO PAGES 52-54 
-From a lofty point in the road he caught a view of Hydra, and, stretching out his hand, exclaimed, “Ah, little England, how long wilt thou escape me?"-GORDON.
-Section 45. didóvaı, Act. Voice, § 262.
-1.  When the Turks retired from Messalonghi (Section 36), they buried their guns, and erected tombstones over them: the Greeks were deceived by this stratagem, and proudly pointed to the inscriptions which recorded the fate of their enemies. When Kiutayhé (or Reschid Pasha, as he was generally called) began the second siege, he dug up the guns and used them against the Greeks.
-2.  εἰ μή except.
-Page [REF]. ei.
-• 
-éyévero if this had not been done, they would have been compelled. Unfulfilled Past Condition.
-1. ÓTÓTE. Cf. [REFn].
-2.  εἴ πως. Cf. [REFn].
-• 
-ἄνευ Toλioρkías, lit. without expense and a siege, i.e., without a costly siege.
-1.  λίθους τε .
-καὶ εἴ τι 
-Cf. [REFn].
-1.  dúvaσbai ǎv would be able; this could have been expressed őri δύναιτο ἄν. Cf. [REFn].
-• 
-1.  οὐδεμίαν avrov they had no hope that (is) they would prevail, unless they were to get possession of it.
-2.  Tò èpyov, i.e., the making of the mound; poσéxovor is Dat. Plur. of Partic.
-Section 46. didóva, Mid. and Pass., § 263.
-1.  καλῶς ἔπραξαν.
-Cf. [REFn].
-Page [REF]. čws äv. Cf. [REFn].
-1.  καθ' ἡμέραν 
-προϊούσαν as each day came on.
-1.  ἀσθενέστεροι ἢ ὥστε too weak to. Cf. [REFn].
-2.  "At Messalonghi, when they issued forth amid the drizzle of the night, feeling their desolation and their doom, they said to one another, 'The Almighty Himself weeps for us to-night!' But they went on, sword in hand, to fall for their country, greeting her with the gladsome cry, 'Arise, thou dearest mother!""GENNADIUS.
-3.  κραυγῇ . by some cry of confusion (lit. of those confused). "Almost at the moment when the garrison rushed on the Turks, that portion of the Messalonghiots which was then on the bridges raised a cry of 'Back, back'. Great part of the Messalonghiots stopt, fell back, and returned into the town with the military escort, which ought to have formed the rear-guard of the sortie. The origin of this ill-timed cry, which weakened the force of the sortie and added to the victims in the place, has excited much unnecessary speculation. It 
-NOTES TO PAGES 54-57 
-91 
-evidently arose among those who were in danger of being forced into the ditch. Their cry was repeated so loudly that it created a panic." FINLAY.
-Page [REF]. ὅσοις ἐντύχοιεν. Cf. [REFn].
-1.  εἴ πως. Cf. [REF].
-2.  âv éyévero. Cf. [REFn]. The deserter was a Bulgarian mer
-cenary.
-Section 47. Str. Aor., ἔβην, ἔγνων, ἑάλων, ἔδυν, §§ [REF].
-1.  où πpoσĥkov, Acc. Abs. See [REFn]. 25. Bore on condition that.
-2.  τοὺς δὲ μὴ δεχομένους.
-(saying) that they would compel those 
-who rejected the terms to observe them. 29. ǎopevo gladly. Cf. [REFn]. Page [REF]. ổơa .
-Section 48.
-idolev. See [REFn].
-1.  The English admiral, Sir Edward Codrington, was in command of the whole fleet, as being the senior admiral. The instructions which he gave to his colleagues in the event of a general engagement concluded with Nelson's words, that no captain could do very wrong who placed his ship alongside that of an enemy.—FYFFE.
-2.  οὐ πολὺς χρόνος. Cf. [REFn].
-Page [REF]. v it was possible. Cf. 1. 8.
-1. rà vaváyia, some of these wrecks are still to be seen on shore and beneath the water.
-2.  ἐμοί 
-• 
-peλnoe, these are the concluding words of Xenophon's Hellenica. uoi is Dat. of Agent, by me.
+1. τὰ περί... *the management of the loan was not in accordance with their views*.
+2. πρίν... καταλύσειαν *until they should overthrow the existing democracy*. The Greeks had elected representatives, but great confusion had arisen owing to party quarrels. If the main verb is negatived, and οὐπρίν *not before* means *not until*, πρίν takes the same construction as μέχρι and ἕως, [REFn]. When πρίν means *before*, it takes the Infin.
+3. οὐ πρότερον πρίν... *not until*; the Indic. is used referring to a Definite time, as is the case with all temporal conjunctions.
+4. διὰ τόν τε θάνατον... καὶ ὅτι... (a) *owing to his son's death, and* (b) *because the conspirators were unsuccessful*. Cf. [REFn].
+5. καθίστατο τοῖς ἐν τοῖς ἀγροῖς *befell the rural population*.
+6. διὰ τὸ ποιεῖσθαι. Cf. [REFn].
+7. It was owing to this Civil War that no assistance had been sent to Cassos and Psara.
+
+
+### Section 43.
+
+ἰέναι Indic. Mood, [REFs].
+
+1. Neocastron, situated on the mainland opposite the south end of Sphakteria, is generally known as Navarino, from some merchants who came from Navarre and settled there in the fifteenth century.
+2. διὰ μάχης ἰέναι *to fight*. Cf. διὰ φόβου εἶναι to be afraid, [REF]. διά in such phrases expresses the *circumstances*, lit. *to come into a state of battle*.
+3. τοιαύτης i.e., against disciplined troops.
+4. Sphakteria is famous as the scene of the Spartan surrender in B.C. 425.
+5. κατὰ τὸν λιμένα *on the harbour side*.
+6. Mavrocordato, being a slow runner, would have been taken prisoner had not two soldiers helped him along, and got him on board a vessel from Hydra, named the Mars. For six hours he sat in the cabin, holding a pistol which might save him the ignominy of being sent in chains to Constantinople; he uttered no word except now and then a brief sentence expressive of the vanity of ambition, and a resolution, if he survived, to retire into private life. Meanwhile the Mars fought her way out of the harbour; the Turkish ships did not dare to approach too near, as the Greek captain could be seen standing with a lighted torch ready to blow up the ship, if any attempt was made to board her. FINLAY.
+
+
+### Section 44. ἰέναι (all), [REFs].
+
+1. εφ' ᾧτε is used with the Fut. Indic. to express *on condition that*. The Pres. Ind. of ἰέναι (and its compounds) has a future meaning: the Past Imperfect and the other moods supply the missing forms of ἔρχομαι.
+2. ὅποι ἂν βούλωνται *whithersoever they wished* (lit. *shall wish*).
+3. εἰ ἐπίοιεν... *if ever the enemy attacked*; after an historic tense, εἰ with the Optat. expresses *if ever*. Cf. [REFn]. When the main verb is primary, the same meaning is expressed by ἤν (= εἰ ἄν), followed by the Subj. Cf. [REF] and [REFn].
+4. παρὰ λόγον *contrary to expectation*.
+5. τήν τε πόλιν... *they burnt* (a) *the town, and* (b) *whatever they could not carry away*. See [REFn].
+6. ἤν πως *if perchance*, i.e., *in hopes that*; after an historic tense, this might be εἴ πως with Optat. Cf. [REF].
+7. When Colokotrones was imprisoned (see [REF]), he exclaimed, "I have twice saved my country, and shall be called upon to save it a third time". GORDON.
+8. The Greeks were so demoralised that Colokotrones had great difficulty in keeping his men together. On one occasion his scouts rushed in crying, "Back, back, there are horsemen in the olive-yard". Presently, however, the horsemen were transformed into a flock of crows and flew away. TRICOUPI.
+9. During this expedition Ibrahim advanced nearly as far as Argos. From a lofty point in the road he caught a view of Hydra, and, stretching out his hand, exclaimed, “Ah, little England, how long wilt thou escape me?" GORDON.
+
+
+### Section 45. διδόναι, Act. Voice, [REFs].
+
+1. When the Turks retired from Messalonghi (Section 36), they buried their guns, and erected tombstones over them: the Greeks were deceived by this stratagem, and proudly pointed to the inscriptions which recorded the fate of their enemies. When Kiutayhé (or Reschid Pasha, as he was generally called) began the second siege, he dug up the guns and used them against the Greeks.
+2. εἰ μή *except*.
+3. εἰ... ἐγένετο *if this had not been done, they would have been compelled*. Unfulfilled Past Condition.
+4. ὁπότε. Cf. [REFn].
+5. εἴ πως. Cf. [REFn].
+6. ἄνευ.. πολιορκίας, lit. *without expense and a siege*, i.e., *without a costly siege*.
+7. λίθους τε... καὶ εἴ τι... Cf. [REFn].
+8. δύνασθαι ἄν *would be able*; this could have been expressed ὅτι δύναιτο ἄν. Cf. [REFn].
+9. οὐδεμίαν... αὐτοῦ *they had no hope that* (ὡς) *they would prevail, unless they were to get possession of it*.
+10. τὸ ἔργον, i.e., the making of the mound; προσέχουσι is Dat. Plur. of Partic.
+
+
+### Section 46.
+
+διδόναι, Mid. and Pass., [REFs].
+
+1. καλῶς ἔπραξαν. Cf. [REFn].
+2. ἕως ἄν. Cf. [REFn].
+3. καθ' ἡμέραν... προϊοῦσαν *as each day came on*.
+4. ἀσθενέστεροι ἢ ὥστε *too weak to*. Cf. [REFn].
+5. "At Messalonghi, when they issued forth amid the drizzle of the night, feeling their desolation and their doom, they said to one another, 'The Almighty Himself weeps for us to-night!' But they went on, sword in hand, to fall for their country, greeting her with the gladsome cry, 'Arise, thou dearest mother!'" GENNADIUS.
+6. κραυγῇ... *by some cry of confusion* (lit. *of those confused*). "Almost at the moment when the garrison rushed on the Turks, that portion of the Messalonghiots which was then on the bridges raised a cry of 'Back, back'. Great part of the Messalonghiots stopt, fell back, and returned into the town with the military escort, which ought to have formed the rear-guard of the sortie. The origin of this ill-timed cry, which weakened the force of the sortie and added to the victims in the place, has excited much unnecessary speculation. It  evidently arose among those who were in danger of being forced into the ditch. Their cry was repeated so loudly that it created a panic." FINLAY.
+7. ὅσοις ἐντύχοιεν. Cf. [REFn].
+8. εἴ πως. Cf. [REF].
+9. ἂν ἐγένετο. Cf. [REFn]. The deserter was a Bulgarian mercenary.
+
+
+### Section 47.
+
+Str. Aor., ἔβην, ἔγνων, ἑάλων, ἔδυν, [REFs].
+
+1. οὐ προσῆκον, Acc. Abs. See [REFn].
+2. ὥστε *on condition that*.
+3. τοὺς δὲ μὴ δεχομένους... *(saying) that they would compel those who rejected the terms to observe them*.
+4. ἄσμενοι gladly. Cf. [REFn].
+5. ὅσα... ἴδοιεν. See [REFn].
+
+### Section 48
+
+1. The English admiral, Sir Edward Codrington, was in command of the whole fleet, as being the senior admiral. The instructions which he gave to his colleagues in the event of a general engagement concluded with Nelson's words, that no captain could do very wrong who placed his ship alongside that of an enemy. FYFFE.
+2. οὐ πολὺς χρόνος. Cf. [REFn].
+3. ἦν *it was possible*. Cf. [REF].
+4. τὰ ναυάγια, some of these wrecks are still to be seen on shore and beneath the water.
+5. ἐμοί... μελήσει, these are the concluding words of Xenophon's *Hellenica*. ἐμοί is Dat. of Agent, *by me*.

--- a/drafts/chambers_notes_ocr.md
+++ b/drafts/chambers_notes_ocr.md
@@ -79,59 +79,56 @@ Pres. Ind. of εἶναι, εἰμί ; of λύειν, λύω, [REF].
 25. τε ... καί ... καί. Introd. Note A. (iii.).
 
 ## Section 2. 
-τὸ δῶρον, p. 143 ; Neut. of στενός, μικρός, p. 145 ; δόξα, p. 142; ὅδε, p. 146.
-1.  κarà την ȧρxýv at the beginning.
-ὅδε this is declined like the Article with de added; when it is used with nouns, the Article must also be used immediately before the noun ; ὁ πόλεμος ὅδε οι ὅδε ὁ πόλεμος this war. For exception, see 5, 4 n.
-1.  οἱ μέν oi δέ.—Introd. Note B. (viii.).
-...
-1.  karà kwμas åteixíorovs in unfortified villages.
-Compound adjectives (a-reixoros un-walled) have no separate form for the Fem. Cf. παραθαλάσσιος, πολυάνθρωπος.
-1.  oi de κáτw but those on the coast, the Article with an adverb forming the equivalent of a noun.-Introd. Note B. (ix.).
-99 66 
-κάτω properly down. The Greeks spoke of "going down to the coast, up into the interior," and "on the high seas," just as we do; the coast is regarded as the lowest point.
-1.  Tòv Tλelotov Toû Bíov the greater part of their livelihood; the adjective is made to agree in gender with the noun in the (partitive) Genitive.
-2.  mapabaλáσoios sc. yn.-Introd. Note B. (ix.).
-3.  vaνrike oxλw with a crowd of sailors; with and by are expressed in Greek by the Dative, corresponding with the Latin (instrumental) Ablative.
-4.  oi ev Ty μeooyeía.-Introd. Note B. (iv.).
-5.  τούς τε ἄλλους to pay tithes of their produce and other taxes; the English order is the reverse of the Greek order.
-NOTES TO PAGES 4, 5 
-1.  Sσre with Ind. introduces a Consecutive Clause, so that. 29. δι' ἁρπαγῆς, see l. 3 n.
-63 
-1.  ὥσπερ κλέπται as Clephts. The Clephts (lit. robbers) were those Greeks, who in defiance of the Turkish authorities carried on a predatory warfare from the hills. Many of them were popular heroes, and their existence helped to keep alive the patriotism of the Greeks.
-Tà Tây TоúρKwv the property of the Turks.-Introd. Note B. (ix.). Page 5, 1. Tŵν πρiv piλwv, see 3, 11.
-1.
-Kívduvos.-Introd. Note B. (v.).
-οὕτω δή in this way. δή only emphasises οὕτω, which sums up what precedes. For omission of conjunction, see Introd. Note A. (ii.).
-Section 3. deσtóτns, p. 143.
-1. dúo airía aide these two causes. If a numeral is used, ὅδε does not require the Article to be inserted with the noun, contrary to the rule given on 4, 12.
-TOÙS VπηKÓοvs subject peoples (in general). The Article denotes a whole class.-Introd. Note B. (vii.).
-1. ἡ τιμωρία τῶν ἀδικιῶν vengeance for their wrongs.
-2. após against.
-3. dia ráde for the following reasons.
-For the omission of a con
-junction in the following sentence, see Introd. Note A. (ii.).
-πρŵтоν μέν is answered by ἔπειτα in l. 16.—Introd. Note A. (iv.). 10. or that introduces a noun-clause, after verbs of thinking, knowing, feeling, seeing, saying, etc.
-avroi (they) themselves, cf. 3, 3 n.
-1.  exovσi Tous deσπóras á§vvérovs lit. they have their masters ignorant, i.e., the masters they have are ignorant. ἀξυνέτους is 8 predicated adjective, and so has no Article. This is the common idiom with ἔχειν.
-• 
-1.  ἄδικα πάσχουσιν ὑπό lit. suffer unjust things by, ie., suffer unjustly at the hands of. iró with Gen. is the ordinary way of expressing the Agent after Passive Verbs (Lat. ab with Abl.); it is also used, as here, with Intransitive Verbs which have a Passive meaning, are unjustly treated by.
-2.  oioi reioí lit. are such as to, i.e., are able to; so oióv r' éotív it is possible. Te in early Greek was added to Relative words, e.g., Sote, and in such cases means nothing at all.
-• 
-· 
-δίκην λαμβάνειν παρά to take vengeance on, lit. to get punishment from. napú with Gen. meaning from is only used of persons. 19. οὐδέν dikalov the judges do not care at all either for the laws or for justice. In Greek two negatives only strengthen one another, provided that the second one is compound. rò díkalov justice. -Introd. Note B. (ix.).
-64 
-1.  μετὰ δώρων . fluence of bribes.
-NOTES TO PAGES 5, 6 
-• 
-they decide cases with gifts, i.e., under the in
-1.  εἰσί is understood with ἔμπειροι δέ from the previous clause. In general if a word or group of words is required with two clauses, it is inserted in the first clause and understood in the second.
-2.  OUTW. See 1 2 n.
-• 
-Page 6, 1. &v of which; the Rel. Pron. ős, 7, 8, is declined in its other cases like the Article with a rough breathing instead of τ, p. 146.
-τὰ μὲν 
-ék dè Tŵv.—Introd. Note B. (viii.). pépe. Neut. Plurals in Greek take a Singular Verb. This arose from an original use of the Neut. Plur. as a singular collective noun.
-1. ἀθάνατον. See 4, 19 n.
-Section 4. Past Imperfect of εἶναι, ή; of λύειν, ἔλυον, p. 147. Syllabic Augment, p. 147; Strong Aorist, p. 148.
+
+τὸ δῶρον, [REF] ; Neut. of στενός, μικρός, [REF]; δόξα, [REF]; ὅδε, [REF].
+
+1. κατὰ τήν ἀρχήν *at the beginning*.
+2. ὅδε this is declined like the Article with δε added; when it is used with nouns, the Article must also be used immediately before the noun; ὁ πόλεμος ὅδε or ὅδε ὁ πόλεμος *this war*. For exception, see [REF] *n*.
+3. οἱ μέν ... οἱ δέ. Introd. Note B. (viii.).
+4. κατὰ κώμας ἀτειχίστους *in unfortified villages*. Compound adjectives (ἀ-τείχιστος *un-walled*) have no separate form for the Fem. *Cf*. παραθαλάσσιος, πολυάνθρωπος [REF].
+5. οἱ δὲ κάτω *but those on the coast*, the Article with an adverb forming the equivalent of a noun. Introd. Note B. (ix.).
+6. κάτω properly *down*. The Greeks spoke of "going *down* to the coast," "*up* into the interior," and "on the *high* seas," just as we do; the coast is regarded as the lowest point.
+7. τὸν πλεῖστον τοῦ βίου *the greater part of their livelihood*; the adjective is made to agree in gender with the noun in the (partitive) Genitive.
+8. ἡ παραθαλάσσιος sc. γῆ. Introd. Note B. (ix.).
+9. ναυτικῷ ὄχλῳ *with a crowd of sailors*; *with* and *by* are expressed in Greek by the Dative, corresponding with the Latin (instrumental) Ablative.
+10. οἱ ἐν τῇ μεσογείᾳ. Introd. Note B. (iv.).
+11. τούς τε ἄλλους... *to pay tithes of their produce and other taxes*; the English order is the reverse of the Greek order.
+12. ὥστε with Ind. introduces a Consecutive Clause, *so that*.
+13. δι' ἁρπαγῆς, see [REF] *n*.
+14. ὥσπερ κλέπται *as Clephts*. The Clephts (lit. robbers) were those Greeks, who in defiance of the Turkish authorities carried on a predatory warfare from the hills. Many of them were popular heroes, and their existence helped to keep alive the patriotism of the Greeks.
+15. τὰ τῶν Τούρκων *the property of the Turks*. Introd. Note B. (ix.).
+16. τῶν πρὶν φίλων, see [REF].
+17. ὁ κίνδυνος. Introd. Note B. (v.).
+18. οὕτω δή *in this way*. δή only emphasises οὕτω, which sums up what precedes. For omission of conjunction, see Introd. Note A. (ii.).
+
+## Section 3.
+
+δεσπότης, [REF].
+
+1. δύο αἰτίαι αἵδε *these two causes*. If a numeral is used, ὅδε does not require the Article to be inserted with the noun, contrary to the rule given on [REF].
+2. τοὺς ὑπηκόους *subject peoples* (in general). The Article denotes a whole class. Introd. Note B. (vii.).
+3. ἡ τιμωρία τῶν ἀδικιῶν *vengeance for their wrongs*.
+4. πρός *against*.
+5. διὰ τάδε *for the following reasons*. For the omission of a conjunction in the following sentence, see Introd. Note A. (ii.).
+6. πρῶτον μέν is answered by ἔπειτα in [REF]. Introd. Note A. (iv.).
+7. ὅτι *that* introduces a noun-clause, after verbs of thinking, knowing, feeling, seeing, saying, etc.
+8. αὐτοί *(they) themselves*, cf. [REF] *n*.
+9. έχουσι τούς δεσπότας ἀξυνέτους lit. *they have their masters ignorant*, i.e., *the masters they have are ignorant*. ἀξυνέτους is a predicated adjective, and so has no Article. This is the common idiom with ἔχειν
+10. ἄδικα πάσχουσιν ὑπό... lit. *suffer unjust things by*, ie., *suffer unjustly at the hands of*. ὑπό with Gen. is the ordinary way of expressing the Agent after Passive Verbs (Lat. *ab* with Abl.); it is also used, as here, with Intransitive Verbs which have a Passive meaning, *are unjustly treated by*.
+11. οἷοι τ' εἰσί lit. *are such as to*, i.e., *are able to*; so οἷόν τ' ἐστίν *it is possible*. τε in early Greek was added to Relative words, e.g., ὥστε, and in such cases means nothing at all.
+12. δίκην λαμβάνειν παρά... *to take vengeance on*, lit. *to get punishment from*. παρά with Gen. meaning *from* is only used of persons. 
+13. οὐδέν... δικαίον *the judges do not care at all either for the laws or for justice*. In Greek two negatives only strengthen one another, provided that the second one is compound. τὸ δίκαιον *justice*. Introd. Note B. (ix.).
+14. μετὰ δώρων... *they decide cases with gifts*, i.e., *under the influence of bribes*.
+15. εἰσί is understood with ἔμπειροι δέ from the previous clause. In general if a word or group of words is required with two clauses, it is inserted in the first clause and understood in the second.
+16. οὕτω. See [REF] *n*.
+17. ὧν *of which*; the Rel. Pron. ὅς, ἥ, ὅ is declined in its other cases like the Article with a rough breathing instead of τ, [REF].
+18. τὰ μὲν... ἐκ δὲ τῶν. Introd. Note Β. (viii.). 
+19. φέρει. Neut. Plurals in Greek take a Singular Verb. This arose from an original use of the Neut. Plur. as a singular collective noun.
+20. ἀθάνατον. See [REF] *n*.
+
+## Section 4. 
+
+Past Imperfect of εἶναι, ή; of λύειν, ἔλυον, p. 147. Syllabic Augment, p. 147; Strong Aorist, p. 148.
 1. κατά αι, cf. 4, 12.
 • 
 1. τοῖς παρά those along the shore of the Black Sea.-Introd. Note B. (iv.). The name Euxine (hospitable) was given it to avoid the original ill-omened name of "Aĝevos (inhospitable).


### PR DESCRIPTION
Add terrible OCR file for the text notes. This needs a ton of manual correction - so far I've done the introductory notes and first section (of 48).

Decisions in how to do this: 
- Goodbye line numbers, we barely knew ya. I'm going to reflow all the references. For now I'm removing the page/line numbers and replacing with `[REF]` - I'll go back and tag with the gltp sentence ids on a second pass. Since we have the pdf we're not losing information, but I think this is better for the digital edition. 
- For notes per section I'm currently just numbering them 1 - n. This may change later but it makes things easier to keep track of while doing the cleaning. 
- There aren't any text checks right now. Not sure if that's possible for such a mixed text and maybe it doesn't matter. 
- I'm going to leave this pr in draft for now and probably not merge until I'm done with the first pass on OCR correction. 